### PR TITLE
Adding artifactory gradle plugin for SNAPSHOTS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
 		classpath("io.spring.gradle:dependency-management-plugin:1.0.5.RELEASE")
 		classpath("io.spring.gradle:spring-io-plugin:0.0.8.RELEASE")
 		classpath("org.asciidoctor:asciidoctor-gradle-plugin:1.5.3")
+		classpath("org.jfrog.buildinfo:build-info-extractor-gradle:4.7.5")
 	}
 }
 
@@ -40,6 +41,8 @@ configure(allprojects) {
 	apply plugin: "propdeps-idea"
 	apply plugin: "propdeps-eclipse"
 	apply plugin: "io.spring.dependency-management"
+	apply plugin: 'maven-publish'
+	apply plugin: "com.jfrog.artifactory"
 
 	ext {
 		openServiceBrokerVersion = "3.0.0.BUILD-SNAPSHOT"
@@ -152,6 +155,20 @@ configure(allprojects) {
 			}
 		}
 	}
+
+	artifactory {
+		contextUrl = 'https://repo.spring.io'
+		publish {
+			repository {
+				repoKey = 'libs-snapshot-local'
+				username = System.getenv()['USERNAME']
+				password = System.getenv()['PASSWORD']
+			}
+			defaults {
+				publications ('mavenJava')
+			}
+		}
+	}
 }
 
 subprojects { subproject ->
@@ -162,6 +179,13 @@ subprojects { subproject ->
 				"${System.getProperty("java.version")} (${System.getProperty("java.specification.vendor")})"
 		manifest.attributes["Implementation-Title"] = subproject.name
 		manifest.attributes["Implementation-Version"] = subproject.version
+
+		from("${rootProject.projectDir}/src/dist") {
+			include "license.txt"
+			include "notice.txt"
+			into "META-INF"
+			expand(copyright: new Date().format("yyyy"), version: subproject.version)
+		}
 	}
 
 	javadoc {
@@ -188,6 +212,17 @@ subprojects { subproject ->
 	artifacts {
 		archives sourcesJar
 		archives javadocJar
+	}
+
+	publishing {
+		publications {
+			mavenJava(MavenPublication) {
+				from components.java
+
+				artifact sourcesJar
+				artifact javadocJar
+			}
+		}
 	}
 
 	configurations {
@@ -305,5 +340,5 @@ codeCoverageReport.dependsOn {
 }
 
 task wrapper(type: Wrapper) {
-	gradleVersion = "4.7"
+	gradleVersion = "4.9"
 }

--- a/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/build.gradle
@@ -16,12 +16,6 @@
 
 description = "Spring Cloud App Broker Deployer Cloud Foundry"
 
-dependencyManagement {
-	imports {
-		mavenBom "org.springframework:spring-framework-bom:${springVersion}"
-	}
-}
-
 ext {
 	reactorNettyVersion = '0.7.5.RELEASE'
 
@@ -35,14 +29,12 @@ ext {
 dependencies {
 	api project(":spring-cloud-app-broker-deployer")
 	api("org.springframework.cloud:spring-cloud-deployer-cloudfoundry:${deployerCFVersion}")
-	constraints {
-		// fix the Boot version to prevent 1.5.x and 2.0.x on the classpath
-		implementation("org.springframework.boot:spring-boot-starter-validation:${springBootVersion}")
-	}
+	// fix the Boot version to prevent 1.5.x and 2.0.x on the classpath
+	implementation("org.springframework.boot:spring-boot-starter-validation:${springBootVersion}")
 
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 
-	testImplementation("org.springframework:spring-test")
+	testImplementation("org.springframework:spring-test:${springVersion}")
 	testImplementation("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
 	testImplementation("org.assertj:assertj-core:${assertjVersion}")
 	testImplementation("org.mockito:mockito-core:${mockitoVersion}")

--- a/spring-cloud-app-broker-deployer/build.gradle
+++ b/spring-cloud-app-broker-deployer/build.gradle
@@ -16,27 +16,19 @@
 
 description = "Spring Cloud App Broker Deployer"
 
-dependencyManagement {
-	imports {
-		mavenBom "org.springframework:spring-framework-bom:${springVersion}"
-	}
-}
-
 ext {
 	deployerVersion = '1.3.3.RELEASE'
 }
 
 dependencies {
 	api("org.springframework.cloud:spring-cloud-deployer-spi:${deployerVersion}")
-	constraints {
-		// fix the Boot version to prevent 1.5.x and 2.0.x on the classpath
-		implementation("org.springframework.boot:spring-boot-starter-validation:${springBootVersion}")
-	}
+	// fix the Boot version to prevent 1.5.x and 2.0.x on the classpath
+	implementation("org.springframework.boot:spring-boot-starter-validation:${springBootVersion}")
 	api("io.projectreactor:reactor-core:${reactorVersion}")
 
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 
-	testImplementation("org.springframework:spring-test")
+	testImplementation("org.springframework:spring-test:${springVersion}")
 	testImplementation("org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}")
 	testImplementation("org.assertj:assertj-core:${assertjVersion}")
 	testImplementation("org.mockito:mockito-core:${mockitoVersion}")


### PR DESCRIPTION
Adding artifactory gradle plugin.
Explicitly setting spring-boot-validator version instead of using the constrain until constrains allow publishing.
Deleting unnecessaries dependencyManagement import.
Upgrading gradle to 4.9.