### PR TITLE
Prevent transforms from accumulating across runs

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
@@ -32,6 +32,23 @@ public class BackingApplication {
 	private List<String> services;
 	private List<ParametersTransformerSpec> parametersTransformers;
 
+	public BackingApplication(BackingApplication backingApplicationToCopy) {
+		this.name = backingApplicationToCopy.name;
+		this.path = backingApplicationToCopy.path;
+		this.properties = backingApplicationToCopy.properties != null
+			? new HashMap<>(backingApplicationToCopy.properties)
+			: new HashMap<>();
+		this.environment = backingApplicationToCopy.environment != null
+			? new HashMap<>(backingApplicationToCopy.environment)
+			: new HashMap<>();
+		this.services = backingApplicationToCopy.services != null
+			? new ArrayList<>(backingApplicationToCopy.services)
+			: new ArrayList<>();
+		this.parametersTransformers = backingApplicationToCopy.parametersTransformers != null
+			? new ArrayList<>(backingApplicationToCopy.parametersTransformers)
+			: new ArrayList<>();
+	}
+
 	private BackingApplication() {
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationService.java
@@ -16,16 +16,17 @@
 
 package org.springframework.cloud.appbroker.extensions.parameters;
 
-import org.springframework.cloud.appbroker.deployer.BackingApplication;
-import org.springframework.cloud.appbroker.deployer.ParametersTransformerSpec;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.ParametersTransformerSpec;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 
 public class ParametersTransformationService {
 	private Map<String, ParametersTransformerFactory<?>> parametersTransformersByName = new HashMap<>();
@@ -38,6 +39,7 @@ public class ParametersTransformationService {
 	public Mono<List<BackingApplication>> transformParameters(List<BackingApplication> backingApplications,
 															  Map<String, Object> parameters) {
 		return Flux.fromIterable(backingApplications)
+			.map(BackingApplication::new)
 			.flatMap(backingApplication -> {
 				List<ParametersTransformerSpec> specs = getTransformerSpecsForApplication(backingApplication);
 

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
@@ -16,21 +16,23 @@
 
 package org.springframework.cloud.appbroker.extensions.parameters;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.cloud.appbroker.deployer.BackingApplication;
-import org.springframework.cloud.appbroker.deployer.BackingApplications;
-import org.springframework.cloud.appbroker.deployer.ParametersTransformerSpec;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.BackingApplications;
+import org.springframework.cloud.appbroker.deployer.ParametersTransformerSpec;
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ParametersTransformationServiceTest {
 	@Test
@@ -115,8 +117,28 @@ class ParametersTransformationServiceTest {
 
 		StepVerifier
 			.create(service.transformParameters(backingApplications, parameters))
-			.expectNext(backingApplications)
+			.expectNextMatches(transformedBackingApplications -> {
+				Map<String, String> app1ExpectedTransformedEnvironment = new HashMap<>(app1.getEnvironment());
+				app1ExpectedTransformedEnvironment.put("0", "transformer1");
+
+				Map<String, String> app2ExpectedTransformedEnvironment = new HashMap<>(app2.getEnvironment());
+				app2ExpectedTransformedEnvironment.put("0", "transformer1");
+				app2ExpectedTransformedEnvironment.put("1", "transformer2");
+
+				assertAll("unexpected transformation results",
+						  () -> assertThat(transformedBackingApplications.size()).isEqualTo(backingApplications.size()),
+						  () -> assertThat(transformedBackingApplications.get(0).getEnvironment()).isEqualTo(app1ExpectedTransformedEnvironment),
+						  () -> assertThat(transformedBackingApplications.get(1).getEnvironment()).isEqualTo(app2ExpectedTransformedEnvironment)
+				);
+
+				return true;
+			})
 			.verifyComplete();
+
+		assertAll("original inputs to the transformation chain must not be modified",
+				  () -> assertThat(app1.getEnvironment()).isEmpty(),
+				  () -> assertThat(app2.getEnvironment()).isEmpty()
+		);
 
 		assertThat(factory1.getActualParameters()).isEqualTo(parameters);
 		assertThat(factory2.getActualParameters()).isEqualTo(parameters);
@@ -150,6 +172,7 @@ class ParametersTransformationServiceTest {
 		private Mono<BackingApplication> doTransform(BackingApplication backingApplication,
 													 Map<String, Object> parameters) {
 			this.actualParameters = parameters;
+			backingApplication.getEnvironment().put(Integer.toString(backingApplication.getEnvironment().size()), getName());
 			return Mono.just(backingApplication);
 		}
 
@@ -168,7 +191,7 @@ class ParametersTransformationServiceTest {
 
 		Config() {
 		}
-		
+
 		Config(String arg1, Integer arg2) {
 			this.arg1 = arg1;
 			this.arg2 = arg2;


### PR DESCRIPTION
Copy each BackingApplication before it enters the ParametersTransformer
chain, ensuring that transformations don't mutate the static
configuration of each app.

closes spring-cloud-incubator/spring-cloud-app-broker#88