### PR TITLE
Multiple workflows

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.appbroker.autoconfigure;
 
-import java.util.List;
-
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -28,14 +26,19 @@ import org.springframework.cloud.appbroker.deployer.DeployerClient;
 import org.springframework.cloud.appbroker.extensions.parameters.EnvironmentMappingParametersTransformerFactory;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformerFactory;
+import org.springframework.cloud.appbroker.service.UpdateServiceInstanceWorkflow;
 import org.springframework.cloud.appbroker.service.WorkflowServiceInstanceService;
 import org.springframework.cloud.appbroker.state.InMemoryServiceInstanceStateRepository;
 import org.springframework.cloud.appbroker.state.ServiceInstanceStateRepository;
-import org.springframework.cloud.appbroker.workflow.instance.CreateServiceInstanceWorkflow;
-import org.springframework.cloud.appbroker.workflow.instance.DeleteServiceInstanceWorkflow;
-import org.springframework.cloud.appbroker.workflow.instance.UpdateServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentCreateServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.service.CreateServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentDeleteServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.service.DeleteServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentUpdateServiceInstanceWorkflow;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 @AutoConfigureAfter(AppDeployerAutoConfiguration.class)
@@ -76,29 +79,30 @@ public class AppBrokerAutoConfiguration {
 	}
 
 	@Bean
-	public CreateServiceInstanceWorkflow createServiceInstanceWorkflow(BrokeredServices brokeredServices,
-																	   BackingAppDeploymentService backingAppDeploymentService,
-																	   ParametersTransformationService parametersTransformationService) {
-		return new CreateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService);
+	public CreateServiceInstanceWorkflow appDeploymentCreateServiceInstanceWorkflow(BrokeredServices brokeredServices,
+																					BackingAppDeploymentService backingAppDeploymentService,
+																					ParametersTransformationService parametersTransformationService) {
+		return new AppDeploymentCreateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService);
 	}
 
 	@Bean
-	public DeleteServiceInstanceWorkflow deleteServiceInstanceWorkflow(BrokeredServices brokeredServices,
-																	   BackingAppDeploymentService backingAppDeploymentService) {
-		return new DeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
+	public DeleteServiceInstanceWorkflow appDeploymentDeleteServiceInstanceWorkflow(BrokeredServices brokeredServices,
+																					BackingAppDeploymentService backingAppDeploymentService) {
+		return new AppDeploymentDeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
 	}
 
-	@Bean UpdateServiceInstanceWorkflow updateServiceInstanceWorkflow(BrokeredServices brokeredServices,
-																	  BackingAppDeploymentService backingAppDeploymentService,
-																	  ParametersTransformationService parametersTransformationService) {
-		return new UpdateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService);
+	@Bean
+	public UpdateServiceInstanceWorkflow updateServiceInstanceWorkflow(BrokeredServices brokeredServices,
+																	   BackingAppDeploymentService backingAppDeploymentService,
+																	   ParametersTransformationService parametersTransformationService) {
+		return new AppDeploymentUpdateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService);
 	}
 
 	@Bean
 	public WorkflowServiceInstanceService serviceInstanceService(ServiceInstanceStateRepository stateRepository,
-																 CreateServiceInstanceWorkflow createWorkflow,
-																 DeleteServiceInstanceWorkflow deleteWorkflow,
-																 UpdateServiceInstanceWorkflow updateWorkflow) {
-		return new WorkflowServiceInstanceService(stateRepository, createWorkflow, deleteWorkflow, updateWorkflow);
+																 List<CreateServiceInstanceWorkflow> createWorkflows,
+																 List<DeleteServiceInstanceWorkflow> deleteWorkflows,
+																 List<UpdateServiceInstanceWorkflow> updateWorkflows) {
+		return new WorkflowServiceInstanceService(stateRepository, createWorkflows, deleteWorkflows, updateWorkflows);
 	}
 }

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -25,8 +25,10 @@ import org.springframework.cloud.appbroker.deployer.BackingApplications;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.deployer.DeployerClient;
 import org.springframework.cloud.appbroker.service.WorkflowServiceInstanceService;
-import org.springframework.cloud.appbroker.workflow.instance.CreateServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentCreateServiceInstanceWorkflow;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentDeleteServiceInstanceWorkflow;
+import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentUpdateServiceInstanceWorkflow;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -92,7 +94,9 @@ class AppBrokerAutoConfigurationTest {
 				assertThat(context).hasSingleBean(BackingAppDeploymentService.class);
 				assertThat(context).hasSingleBean(ParametersTransformationService.class);
 				assertThat(context).hasSingleBean(WorkflowServiceInstanceService.class);
-				assertThat(context).hasSingleBean(CreateServiceInstanceWorkflow.class);
+				assertThat(context).hasSingleBean(AppDeploymentCreateServiceInstanceWorkflow.class);
+				assertThat(context).hasSingleBean(AppDeploymentDeleteServiceInstanceWorkflow.class);
+				assertThat(context).hasSingleBean(AppDeploymentUpdateServiceInstanceWorkflow.class);
 			});
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingAppDeploymentService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingAppDeploymentService.java
@@ -17,10 +17,8 @@
 package org.springframework.cloud.appbroker.deployer;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import reactor.util.Logger;
 import reactor.util.Loggers;
@@ -34,27 +32,27 @@ public class BackingAppDeploymentService {
 		this.deployerClient = deployerClient;
 	}
 
-	public Mono<String> deploy(List<BackingApplication> backingApps) {
+	public Flux<String> deploy(List<BackingApplication> backingApps) {
 		return Flux.fromIterable(backingApps)
 			.parallel()
 			.runOn(Schedulers.parallel())
 			.flatMap(deployerClient::deploy)
 			.doOnRequest(l -> log.info("Deploying applications {}", backingApps))
-			.doOnEach(d -> log.info("Finished deploying applications {}", backingApps))
+			.doOnEach(d -> log.info("Finished deploying application {}", d))
+			.doOnComplete(() -> log.info("Finished deploying application {}", backingApps))
 			.doOnError(e -> log.info("Error deploying applications {} with error {}", backingApps, e))
-			.sequential()
-			.collect(Collectors.joining(","));
+			.sequential();
 	}
 
-	public Mono<String> undeploy(List<BackingApplication> backingApps) {
+	public Flux<String> undeploy(List<BackingApplication> backingApps) {
 		return Flux.fromIterable(backingApps)
 			.parallel()
 			.runOn(Schedulers.parallel())
 			.flatMap(deployerClient::undeploy)
 			.doOnRequest(l -> log.info("Undeploying applications {}", backingApps))
-			.doOnEach(d -> log.info("Finished undeploying applications {}", backingApps))
+			.doOnEach(d -> log.info("Finished undeploying application {}", d))
+			.doOnComplete(() -> log.info("Finished undeploying application {}", backingApps))
 			.doOnError(e -> log.info("Error undeploying applications {} with error {}", backingApps, e))
-			.sequential()
-			.collect(Collectors.joining(","));
+			.sequential();
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/CreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/CreateServiceInstanceWorkflow.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.service;
+
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+import reactor.core.publisher.Mono;
+
+public interface CreateServiceInstanceWorkflow {
+	Mono<String> create(CreateServiceInstanceRequest request);
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/CreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/CreateServiceInstanceWorkflow.java
@@ -17,8 +17,8 @@
 package org.springframework.cloud.appbroker.service;
 
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 public interface CreateServiceInstanceWorkflow {
-	Mono<String> create(CreateServiceInstanceRequest request);
+	Flux<Void> create(CreateServiceInstanceRequest request);
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/DeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/DeleteServiceInstanceWorkflow.java
@@ -17,8 +17,8 @@
 package org.springframework.cloud.appbroker.service;
 
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 public interface DeleteServiceInstanceWorkflow {
-	Mono<String> delete(DeleteServiceInstanceRequest request);
+	Flux<Void> delete(DeleteServiceInstanceRequest request);
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/DeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/DeleteServiceInstanceWorkflow.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.service;
+
+import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
+import reactor.core.publisher.Mono;
+
+public interface DeleteServiceInstanceWorkflow {
+	Mono<String> delete(DeleteServiceInstanceRequest request);
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/UpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/UpdateServiceInstanceWorkflow.java
@@ -17,8 +17,8 @@
 package org.springframework.cloud.appbroker.service;
 
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 public interface UpdateServiceInstanceWorkflow {
-	Mono<String> update(UpdateServiceInstanceRequest request);
+	Flux<Void> update(UpdateServiceInstanceRequest request);
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/UpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/UpdateServiceInstanceWorkflow.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.service;
+
+import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
+import reactor.core.publisher.Mono;
+
+public interface UpdateServiceInstanceWorkflow {
+	Mono<String> update(UpdateServiceInstanceRequest request);
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceService.java
@@ -32,6 +32,7 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceResponse;
 import org.springframework.cloud.servicebroker.service.ServiceInstanceService;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -63,6 +64,10 @@ public class WorkflowServiceInstanceService implements ServiceInstanceService {
 		this.createServiceInstanceWorkflows = createServiceInstanceWorkflows;
 		this.deleteServiceInstanceWorkflows = deleteServiceInstanceWorkflows;
 		this.updateServiceInstanceWorkflows = updateServiceInstanceWorkflows;
+
+		AnnotationAwareOrderComparator.sort(this.createServiceInstanceWorkflows);
+		AnnotationAwareOrderComparator.sort(this.deleteServiceInstanceWorkflows);
+		AnnotationAwareOrderComparator.sort(this.updateServiceInstanceWorkflows);
 	}
 
 	@Override

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
@@ -16,35 +16,39 @@
 
 package org.springframework.cloud.appbroker.workflow.instance;
 
+import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
+import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
+import org.springframework.cloud.appbroker.service.CreateServiceInstanceWorkflow;
 import reactor.core.publisher.Mono;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
+
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
-import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
-import org.springframework.cloud.appbroker.deployer.BrokeredServices;
-import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
-import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
-
-public class UpdateServiceInstanceWorkflow extends ServiceInstanceWorkflow {
-	private final Logger log = Loggers.getLogger(UpdateServiceInstanceWorkflow.class);
+public class AppDeploymentCreateServiceInstanceWorkflow
+	extends AppDeploymentInstanceWorkflow
+	implements CreateServiceInstanceWorkflow {
+	private final Logger log = Loggers.getLogger(AppDeploymentCreateServiceInstanceWorkflow.class);
 
 	private BackingAppDeploymentService deploymentService;
 	private ParametersTransformationService parametersTransformationService;
 
-	public UpdateServiceInstanceWorkflow(BrokeredServices brokeredServices,
-										 BackingAppDeploymentService deploymentService,
-										 ParametersTransformationService parametersTransformationService) {
+	public AppDeploymentCreateServiceInstanceWorkflow(BrokeredServices brokeredServices,
+													  BackingAppDeploymentService deploymentService,
+													  ParametersTransformationService parametersTransformationService) {
 		super(brokeredServices);
 		this.deploymentService = deploymentService;
 		this.parametersTransformationService = parametersTransformationService;
 	}
 
-	public Mono<String> update(UpdateServiceInstanceRequest request) {
+	@Override
+	public Mono<String> create(CreateServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlanId())
 			.flatMap(backingApps -> parametersTransformationService.transformParameters(backingApps, request.getParameters()))
 			.flatMap(deploymentService::deploy)
-			.doOnRequest(l -> log.info("Updating applications {}", brokeredServices))
-			.doOnSuccess(d -> log.info("Finished updating applications {}", brokeredServices))
-			.doOnError(e -> log.info("Error updating applications {} with error {}", brokeredServices, e));
+			.doOnRequest(l -> log.info("Deploying applications {}", brokeredServices))
+			.doOnSuccess(d -> log.info("Finished deploying applications {}", brokeredServices))
+			.doOnError(e -> log.info("Error deploying applications {} with error {}", brokeredServices, e));
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflow.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.appbroker.workflow.instance;
 import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceWorkflow;
+import org.springframework.core.annotation.Order;
 import reactor.core.publisher.Mono;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
@@ -26,6 +27,7 @@ import org.springframework.cloud.servicebroker.model.instance.CreateServiceInsta
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
+@Order(0)
 public class AppDeploymentCreateServiceInstanceWorkflow
 	extends AppDeploymentInstanceWorkflow
 	implements CreateServiceInstanceWorkflow {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
@@ -19,10 +19,12 @@ package org.springframework.cloud.appbroker.workflow.instance;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.service.DeleteServiceInstanceWorkflow;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
+import org.springframework.core.annotation.Order;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
 
+@Order(0)
 public class AppDeploymentDeleteServiceInstanceWorkflow
 	extends AppDeploymentInstanceWorkflow
 	implements DeleteServiceInstanceWorkflow {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
@@ -20,14 +20,18 @@ import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.service.DeleteServiceInstanceWorkflow;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
 import org.springframework.core.annotation.Order;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
+import reactor.util.Logger;
+import reactor.util.Loggers;
 
 @Order(0)
 public class AppDeploymentDeleteServiceInstanceWorkflow
 	extends AppDeploymentInstanceWorkflow
 	implements DeleteServiceInstanceWorkflow {
+	private final Logger log = Loggers.getLogger(AppDeploymentDeleteServiceInstanceWorkflow.class);
+
 	private final BackingAppDeploymentService deploymentService;
 
 	public AppDeploymentDeleteServiceInstanceWorkflow(BrokeredServices brokeredServices,
@@ -37,8 +41,13 @@ public class AppDeploymentDeleteServiceInstanceWorkflow
 	}
 
 	@Override
-	public Mono<String> delete(DeleteServiceInstanceRequest request) {
+	public Flux<Void> delete(DeleteServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlanId())
-			.flatMap(deploymentService::undeploy);
+			.flatMapMany(deploymentService::undeploy)
+			.doOnRequest(l -> log.info("Undeploying applications {}", brokeredServices))
+			.doOnEach(s -> log.info("Finished undeploying {}", s))
+			.doOnComplete(() -> log.info("Finished undeploying applications {}", brokeredServices))
+			.doOnError(e -> log.info("Error undeploying applications {} with error {}", brokeredServices, e))
+			.flatMap(apps -> Flux.empty());
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflow.java
@@ -17,20 +17,24 @@
 package org.springframework.cloud.appbroker.workflow.instance;
 
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.service.DeleteServiceInstanceWorkflow;
 import org.springframework.cloud.servicebroker.model.instance.DeleteServiceInstanceRequest;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
 
-public class DeleteServiceInstanceWorkflow extends ServiceInstanceWorkflow {
+public class AppDeploymentDeleteServiceInstanceWorkflow
+	extends AppDeploymentInstanceWorkflow
+	implements DeleteServiceInstanceWorkflow {
 	private final BackingAppDeploymentService deploymentService;
 
-	public DeleteServiceInstanceWorkflow(BrokeredServices brokeredServices,
-										 BackingAppDeploymentService deploymentService) {
+	public AppDeploymentDeleteServiceInstanceWorkflow(BrokeredServices brokeredServices,
+													  BackingAppDeploymentService deploymentService) {
 		super(brokeredServices);
 		this.deploymentService = deploymentService;
 	}
 
+	@Override
 	public Mono<String> delete(DeleteServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlanId())
 			.flatMap(deploymentService::undeploy);

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
@@ -25,11 +25,11 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-public class AppDeploymentInstanceWorkflow {
+class AppDeploymentInstanceWorkflow {
 
 	final BrokeredServices brokeredServices;
 
-	public AppDeploymentInstanceWorkflow(BrokeredServices brokeredServices) {
+	AppDeploymentInstanceWorkflow(BrokeredServices brokeredServices) {
 		this.brokeredServices = brokeredServices;
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflow.java
@@ -25,11 +25,11 @@ import reactor.core.publisher.Mono;
 
 import java.util.List;
 
-public class ServiceInstanceWorkflow {
+public class AppDeploymentInstanceWorkflow {
 
 	final BrokeredServices brokeredServices;
 
-	public ServiceInstanceWorkflow(BrokeredServices brokeredServices) {
+	public AppDeploymentInstanceWorkflow(BrokeredServices brokeredServices) {
 		this.brokeredServices = brokeredServices;
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
@@ -16,35 +16,38 @@
 
 package org.springframework.cloud.appbroker.workflow.instance;
 
-import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
-import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
+import org.springframework.cloud.appbroker.service.UpdateServiceInstanceWorkflow;
 import reactor.core.publisher.Mono;
-import org.springframework.cloud.appbroker.deployer.BrokeredServices;
-import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
-
 import reactor.util.Logger;
 import reactor.util.Loggers;
 
-public class CreateServiceInstanceWorkflow extends ServiceInstanceWorkflow {
-	private final Logger log = Loggers.getLogger(CreateServiceInstanceWorkflow.class);
+import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
+import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
+import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
+
+public class AppDeploymentUpdateServiceInstanceWorkflow
+	extends AppDeploymentInstanceWorkflow
+	implements UpdateServiceInstanceWorkflow {
+	private final Logger log = Loggers.getLogger(AppDeploymentUpdateServiceInstanceWorkflow.class);
 
 	private BackingAppDeploymentService deploymentService;
 	private ParametersTransformationService parametersTransformationService;
 
-	public CreateServiceInstanceWorkflow(BrokeredServices brokeredServices,
-										 BackingAppDeploymentService deploymentService,
-										 ParametersTransformationService parametersTransformationService) {
+	public AppDeploymentUpdateServiceInstanceWorkflow(BrokeredServices brokeredServices,
+													  BackingAppDeploymentService deploymentService,
+													  ParametersTransformationService parametersTransformationService) {
 		super(brokeredServices);
 		this.deploymentService = deploymentService;
 		this.parametersTransformationService = parametersTransformationService;
 	}
 
-	public Mono<String> create(CreateServiceInstanceRequest request) {
+	public Mono<String> update(UpdateServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlanId())
 			.flatMap(backingApps -> parametersTransformationService.transformParameters(backingApps, request.getParameters()))
 			.flatMap(deploymentService::deploy)
-			.doOnRequest(l -> log.info("Deploying applications {}", brokeredServices))
-			.doOnSuccess(d -> log.info("Finished deploying applications {}", brokeredServices))
-			.doOnError(e -> log.info("Error deploying applications {} with error {}", brokeredServices, e));
+			.doOnRequest(l -> log.info("Updating applications {}", brokeredServices))
+			.doOnSuccess(d -> log.info("Finished updating applications {}", brokeredServices))
+			.doOnError(e -> log.info("Error updating applications {} with error {}", brokeredServices, e));
 	}
 }

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/service/WorkflowServiceInstanceServiceTest.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.servicebroker.model.instance.OperationState;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -89,9 +90,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 
 		given(createServiceInstanceWorkflow1.create(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 		given(createServiceInstanceWorkflow2.create(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.createServiceInstance(request))
 			.assertNext(createServiceInstanceResponse -> {
@@ -124,9 +125,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 
 		given(createServiceInstanceWorkflow1.create(request))
-			.willReturn(Mono.error(new RuntimeException("create foo error")));
+			.willReturn(Flux.error(new RuntimeException("create foo error")));
 		given(createServiceInstanceWorkflow2.create(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.createServiceInstance(request))
 			.assertNext(error -> {
@@ -156,9 +157,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 
 		given(deleteServiceInstanceWorkflow1.delete(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 		given(deleteServiceInstanceWorkflow2.delete(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.deleteServiceInstance(request))
 			.consumeNextWith(deleteServiceInstanceResponse -> {
@@ -191,9 +192,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 		
 		given(deleteServiceInstanceWorkflow1.delete(request))
-			.willReturn(Mono.error(new RuntimeException("delete foo error")));
+			.willReturn(Flux.error(new RuntimeException("delete foo error")));
 		given(deleteServiceInstanceWorkflow2.delete(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.deleteServiceInstance(request))
 			.consumeNextWith(deleteServiceInstanceResponse -> {
@@ -226,9 +227,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 
 		given(updateServiceInstanceWorkflow1.update(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 		given(updateServiceInstanceWorkflow2.update(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.updateServiceInstance(request))
 			.assertNext(updateServiceInstanceResponse -> {
@@ -261,9 +262,9 @@ class WorkflowServiceInstanceServiceTest {
 			.build();
 
 		given(updateServiceInstanceWorkflow1.update(request))
-			.willReturn(Mono.error(new RuntimeException("update foo error")));
+			.willReturn(Flux.error(new RuntimeException("update foo error")));
 		given(updateServiceInstanceWorkflow2.update(request))
-			.willReturn(Mono.empty());
+			.willReturn(Flux.empty());
 
 		StepVerifier.create(workflowServiceInstanceService.updateServiceInstance(request))
 			.assertNext(error -> {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentDeleteServiceInstanceWorkflowTest.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.appbroker.deployer.BackingApplication;
 import org.springframework.cloud.appbroker.deployer.BackingApplications;
 import org.springframework.cloud.appbroker.deployer.BrokeredService;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.service.DeleteServiceInstanceWorkflow;
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
@@ -38,7 +39,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
-class DeleteServiceInstanceWorkflowTest {
+class AppDeploymentDeleteServiceInstanceWorkflowTest {
 
 	@Mock
 	private BackingAppDeploymentService backingAppDeploymentService;
@@ -69,7 +70,7 @@ class DeleteServiceInstanceWorkflowTest {
 			.willReturn(Mono.just("undeployed"));
 
 		DeleteServiceInstanceWorkflow deleteServiceInstanceWorkflow =
-			new DeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
+			new AppDeploymentDeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
 
 		// when
 		StepVerifier
@@ -83,7 +84,7 @@ class DeleteServiceInstanceWorkflowTest {
 	@Test
 	void deleteServiceInstanceFailsWithMisconfigurationFails() {
 		DeleteServiceInstanceWorkflow deleteServiceInstanceWorkflow =
-			new DeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
+			new AppDeploymentDeleteServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService);
 
 		// when
 		StepVerifier

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentInstanceWorkflowTest.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import reactor.test.StepVerifier;
 
-class ServiceInstanceWorkflowTest {
+class AppDeploymentInstanceWorkflowTest {
 
 	private BrokeredServices brokeredServices;
 	private BackingApplications backingApps;
@@ -52,10 +52,10 @@ class ServiceInstanceWorkflowTest {
 
 	@Test
 	void getBackingAppForServiceSucceeds() {
-		ServiceInstanceWorkflow serviceInstanceWorkflow = new ServiceInstanceWorkflow(brokeredServices);
+		AppDeploymentInstanceWorkflow appDeploymentInstanceWorkflow = new AppDeploymentInstanceWorkflow(brokeredServices);
 
 		StepVerifier
-			.create(serviceInstanceWorkflow
+			.create(appDeploymentInstanceWorkflow
 				.getBackingApplicationsForService(buildServiceDefinition("service1", "plan1"), "plan1-id"))
 			.expectNext(backingApps)
 			.verifyComplete();
@@ -63,10 +63,10 @@ class ServiceInstanceWorkflowTest {
 
 	@Test
 	void getBackingAppForServiceWithUnknownServiceIdFails() {
-		ServiceInstanceWorkflow serviceInstanceWorkflow = new ServiceInstanceWorkflow(brokeredServices);
+		AppDeploymentInstanceWorkflow appDeploymentInstanceWorkflow = new AppDeploymentInstanceWorkflow(brokeredServices);
 
 		StepVerifier
-			.create(serviceInstanceWorkflow
+			.create(appDeploymentInstanceWorkflow
 				.getBackingApplicationsForService(buildServiceDefinition("unknown-service", "plan1"), "plan1-id"))
 		.expectError(ServiceBrokerException.class)
 		.verify();
@@ -74,10 +74,10 @@ class ServiceInstanceWorkflowTest {
 
 	@Test
 	void getBackingAppForServiceWithUnknownPlanIdFails() {
-		ServiceInstanceWorkflow serviceInstanceWorkflow = new ServiceInstanceWorkflow(brokeredServices);
+		AppDeploymentInstanceWorkflow appDeploymentInstanceWorkflow = new AppDeploymentInstanceWorkflow(brokeredServices);
 
 		StepVerifier
-			.create(serviceInstanceWorkflow
+			.create(appDeploymentInstanceWorkflow
 				.getBackingApplicationsForService(buildServiceDefinition("service1", "unknown-plan"), "unknown-plan-id"))
 		.expectError(ServiceBrokerException.class)
 		.verify();


### PR DESCRIPTION
Allow implementing brokers to provide their own implementations of `CreateServiceInstanceWorkflow` , `DeleteServiceInstanceWorkflow`, and `UpdateServiceInstanceWorkflow` beans to perform operations in addition to app deployment. 

Fixes #81, #82, #89, #98 