### PR TITLE
Hide potentially sensitive logs output when serializing backing app

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 
 public class BackingApplication {
 
+	private static final String VALUE_HIDDEN = "<value hidden>";
 	private String name;
 	private String path;
 	private Map<String, String> properties;
@@ -139,10 +140,17 @@ public class BackingApplication {
 			"name='" + name + '\'' +
 			", path='" + path + '\'' +
 			", properties=" + properties +
-			", environment=" + environment +
+			", environment=" + sanitizeEnvironment(environment) +
 			", services=" + services +
 			", parametersTransformers=" + parametersTransformers +
 			'}';
+	}
+
+	private Map<String, String> sanitizeEnvironment(Map<String, String> environment) {
+		HashMap<String, String> sanitizedEnvironment = new HashMap<>();
+		environment.forEach((key, value) -> sanitizedEnvironment.put(key, VALUE_HIDDEN));
+
+		return sanitizedEnvironment;
 	}
 
 	public static class BackingApplicationBuilder {

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/BackingApplicationTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/BackingApplicationTest.java
@@ -1,0 +1,29 @@
+package org.springframework.cloud.appbroker.deployer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BackingApplicationTest {
+
+	@Test
+	void stringRepresentationShouldNotExposeSensitiveInformationFromTheEnvironment() {
+		BackingApplication backingApp = BackingApplication
+			.builder()
+			.name("Test")
+			.environment("privateKey", "secret-private-key")
+			.environment("databasePassword", "password")
+			.build();
+
+		String backingAppAsString = backingApp.toString();
+
+		assertThat(backingAppAsString).doesNotContain("secret-private-key");
+		assertThat(backingAppAsString).doesNotContain("password");
+
+		assertThat(backingAppAsString).contains("privateKey=<value hidden>");
+		assertThat(backingAppAsString).contains("databasePassword=<value hidden>");
+
+		assertThat(backingApp.getEnvironment().get("privateKey")).isEqualTo("secret-private-key");
+		assertThat(backingApp.getEnvironment().get("databasePassword")).isEqualTo("password");
+	}
+}


### PR DESCRIPTION
Closes https://github.com/spring-cloud-incubator/spring-cloud-app-broker/issues/107