### PR TITLE
Fix NPE when logging backing application

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
@@ -147,6 +147,8 @@ public class BackingApplication {
 	}
 
 	private Map<String, String> sanitizeEnvironment(Map<String, String> environment) {
+		if (environment == null) return environment;
+
 		HashMap<String, String> sanitizedEnvironment = new HashMap<>();
 		environment.forEach((key, value) -> sanitizedEnvironment.put(key, VALUE_HIDDEN));
 

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/BackingApplicationTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/deployer/BackingApplicationTest.java
@@ -25,5 +25,8 @@ class BackingApplicationTest {
 
 		assertThat(backingApp.getEnvironment().get("privateKey")).isEqualTo("secret-private-key");
 		assertThat(backingApp.getEnvironment().get("databasePassword")).isEqualTo("password");
+
+		backingApp.setEnvironment(null);
+		assertThat(backingApp.toString()).isNotEmpty();
 	}
 }


### PR DESCRIPTION
When BackingApplication is built from properties but not with the builder it might trigger NPE when logging.