### PR TITLE
Add support for configurable credential providers and a SpringSecurityBasicAuth provider.

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.appbroker.deployer.BackingAppDeploymentService;
 import org.springframework.cloud.appbroker.deployer.BackingApplications;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.deployer.DeployerClient;
+import org.springframework.cloud.appbroker.extensions.credentials.CredentialProviderService;
 import org.springframework.cloud.appbroker.service.WorkflowServiceInstanceService;
 import org.springframework.cloud.appbroker.workflow.instance.AppDeploymentCreateServiceInstanceWorkflow;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
@@ -93,6 +94,7 @@ class AppBrokerAutoConfigurationTest {
 				assertThat(context).hasSingleBean(BrokeredServices.class);
 				assertThat(context).hasSingleBean(BackingAppDeploymentService.class);
 				assertThat(context).hasSingleBean(ParametersTransformationService.class);
+				assertThat(context).hasSingleBean(CredentialProviderService.class);
 				assertThat(context).hasSingleBean(WorkflowServiceInstanceService.class);
 				assertThat(context).hasSingleBean(AppDeploymentCreateServiceInstanceWorkflow.class);
 				assertThat(context).hasSingleBean(AppDeploymentDeleteServiceInstanceWorkflow.class);

--- a/spring-cloud-app-broker-core/build.gradle
+++ b/spring-cloud-app-broker-core/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	api("org.springframework:spring-core")
 	api("org.springframework:spring-context")
 	api("org.springframework.cloud:spring-cloud-open-service-broker-core:${openServiceBrokerVersion}")
+	api("org.apache.commons:commons-text:1.4")
 
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}")
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/BackingApplication.java
@@ -26,12 +26,14 @@ import java.util.Objects;
 public class BackingApplication {
 
 	private static final String VALUE_HIDDEN = "<value hidden>";
+	
 	private String name;
 	private String path;
 	private Map<String, String> properties;
 	private Map<String, String> environment;
 	private List<String> services;
 	private List<ParametersTransformerSpec> parametersTransformers;
+	private List<CredentialProviderSpec> credentialProviders;
 
 	public BackingApplication(BackingApplication backingApplicationToCopy) {
 		this.name = backingApplicationToCopy.name;
@@ -48,6 +50,9 @@ public class BackingApplication {
 		this.parametersTransformers = backingApplicationToCopy.parametersTransformers != null
 			? new ArrayList<>(backingApplicationToCopy.parametersTransformers)
 			: new ArrayList<>();
+		this.credentialProviders = backingApplicationToCopy.credentialProviders != null
+			? new ArrayList<>(backingApplicationToCopy.credentialProviders)
+			: new ArrayList<>();
 	}
 
 	private BackingApplication() {
@@ -55,13 +60,15 @@ public class BackingApplication {
 
 	private BackingApplication(String name, String path, Map<String, String> properties,
 							   Map<String, String> environment, List<String> services,
-							   List<ParametersTransformerSpec> parametersTransformers) {
+							   List<ParametersTransformerSpec> parametersTransformers,
+							   List<CredentialProviderSpec> credentialProviders) {
 		this.name = name;
 		this.path = path;
 		this.properties = properties;
 		this.environment = environment;
 		this.services = services;
 		this.parametersTransformers = parametersTransformers;
+		this.credentialProviders = credentialProviders;
 	}
 
 	public String getName() {
@@ -96,6 +103,10 @@ public class BackingApplication {
 		this.environment = environment;
 	}
 
+	public void addEnvironment(String key, String value) {
+		environment.put(key, value);
+	}
+
 	public List<String> getServices() {
 		return services;
 	}
@@ -112,6 +123,14 @@ public class BackingApplication {
 		this.parametersTransformers = parametersTransformers;
 	}
 
+	public List<CredentialProviderSpec> getCredentialProviders() {
+		return credentialProviders;
+	}
+
+	public void setCredentialProviders(List<CredentialProviderSpec> credentialProviders) {
+		this.credentialProviders = credentialProviders;
+	}
+
 	public static BackingApplicationBuilder builder() {
 		return new BackingApplicationBuilder();
 	}
@@ -126,12 +145,14 @@ public class BackingApplication {
 			Objects.equals(properties, that.properties) &&
 			Objects.equals(environment, that.environment) &&
 			Objects.equals(services, that.services) &&
-			Objects.equals(parametersTransformers, that.parametersTransformers);
+			Objects.equals(parametersTransformers, that.parametersTransformers) &&
+			Objects.equals(credentialProviders, that.credentialProviders);
 	}
 
 	@Override
 	public final int hashCode() {
-		return Objects.hash(name, path, properties, environment, services, parametersTransformers);
+		return Objects.hash(name, path, properties, environment, services,
+			parametersTransformers, credentialProviders);
 	}
 
 	@Override
@@ -143,11 +164,14 @@ public class BackingApplication {
 			", environment=" + sanitizeEnvironment(environment) +
 			", services=" + services +
 			", parametersTransformers=" + parametersTransformers +
+			", credentialProviders=" + credentialProviders +
 			'}';
 	}
 
 	private Map<String, String> sanitizeEnvironment(Map<String, String> environment) {
-		if (environment == null) return environment;
+		if (environment == null) {
+			return null;
+		}
 
 		HashMap<String, String> sanitizedEnvironment = new HashMap<>();
 		environment.forEach((key, value) -> sanitizedEnvironment.put(key, VALUE_HIDDEN));
@@ -163,6 +187,7 @@ public class BackingApplication {
 		private Map<String, String> environment = new HashMap<>();
 		private List<String> services = new ArrayList<>();
 		private List<ParametersTransformerSpec> parameterTransformers = new ArrayList<>();
+		private List<CredentialProviderSpec> credentialProviders = new ArrayList<>();
 
 		BackingApplicationBuilder() {
 		}
@@ -202,13 +227,19 @@ public class BackingApplication {
 			return this;
 		}
 
-		public BackingApplicationBuilder parameterTransformers(ParametersTransformerSpec... parameterTransformer) {
-			this.parameterTransformers.addAll(Arrays.asList(parameterTransformer));
+		public BackingApplicationBuilder parameterTransformers(ParametersTransformerSpec... parameterTransformers) {
+			this.parameterTransformers.addAll(Arrays.asList(parameterTransformers));
+			return this;
+		}
+
+		public BackingApplicationBuilder credentialProviders(CredentialProviderSpec... credentialProviders) {
+			this.credentialProviders.addAll(Arrays.asList(credentialProviders));
 			return this;
 		}
 
 		public BackingApplication build() {
-			return new BackingApplication(name, path, properties, environment, services, parameterTransformers);
+			return new BackingApplication(name, path, properties, environment, services,
+				parameterTransformers, credentialProviders);
 		}
 	}
 }

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/CredentialProviderSpec.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/deployer/CredentialProviderSpec.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.deployer;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class CredentialProviderSpec {
+	private String name;
+	private Map<String, Object> args;
+
+	private CredentialProviderSpec() {
+	}
+
+	private CredentialProviderSpec(String name, Map<String, Object> args) {
+		this.name = name;
+		this.args = args;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Map<String, Object> getArgs() {
+		return args;
+	}
+
+	public void setArgs(Map<String, Object> args) {
+		this.args = args;
+	}
+
+	public static CredentialProviderSpecBuilder builder() {
+		return new CredentialProviderSpecBuilder();
+	}
+
+	public static class CredentialProviderSpecBuilder {
+		private String name;
+		private Map<String, Object> args = new LinkedHashMap<>();
+
+		private CredentialProviderSpecBuilder() {
+		}
+
+		public CredentialProviderSpecBuilder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public CredentialProviderSpecBuilder arg(String key, Object value) {
+			this.args.put(key, value);
+			return this;
+		}
+
+		public CredentialProviderSpecBuilder args(Map<String, Object> args) {
+			this.args.putAll(args);
+			return this;
+		}
+
+		public CredentialProviderSpec build() {
+			return new CredentialProviderSpec(name, args);
+		}
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/AbstractExtensionFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/AbstractExtensionFactory.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.appbroker.extensions;
 
+import org.springframework.cloud.appbroker.extensions.support.ConfigurationBeanUtils;
+
 import java.util.Map;
 import java.util.function.Consumer;
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.appbroker.extensions.credentials;
 import org.apache.commons.lang3.tuple.Pair;
 
 public interface CredentialGenerator {
+
 	Pair<String, String> generateUser(String applicationId, String serviceInstanceId,
 									  int length, boolean includeUppercaseAlpha,
 									  boolean includeLowercaseAlpha, boolean includeNumeric,

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+public interface CredentialGenerator {
+	Pair<String, String> generateUser(String applicationId, String serviceInstanceId,
+									  int length, boolean includeUppercaseAlpha,
+									  boolean includeLowercaseAlpha, boolean includeNumeric,
+									  boolean includeSpecial);
+
+	String generateString(String applicationId, String serviceInstanceId,
+						  int length, boolean includeUppercaseAlpha,
+						  boolean includeLowercaseAlpha, boolean includeNumeric,
+						  boolean includeSpecial);
+
+	default void deleteUser(String applicationId, String serviceInstanceId) {
+	}
+
+	default void deleteString(String applicationId, String serviceInstanceId) {
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProvider.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProvider.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import reactor.core.publisher.Mono;
+
+public interface CredentialProvider {
+	Mono<BackingApplication> addCredentials(BackingApplication backingApplication, String serviceInstanceGuid);
+
+	default Mono<BackingApplication> deleteCredentials(BackingApplication backingApplication, String serviceInstanceGuid) {
+		return Mono.just(backingApplication);
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProvider.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProvider.java
@@ -20,6 +20,7 @@ import org.springframework.cloud.appbroker.deployer.BackingApplication;
 import reactor.core.publisher.Mono;
 
 public interface CredentialProvider {
+
 	Mono<BackingApplication> addCredentials(BackingApplication backingApplication, String serviceInstanceGuid);
 
 	default Mono<BackingApplication> deleteCredentials(BackingApplication backingApplication, String serviceInstanceGuid) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderFactory.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.appbroker.extensions.credentials;
 import org.springframework.cloud.appbroker.extensions.AbstractExtensionFactory;
 
 public abstract class CredentialProviderFactory<C> extends AbstractExtensionFactory<CredentialProvider, C> {
+
 	protected CredentialProviderFactory() {
 		super();
 	}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.springframework.cloud.appbroker.extensions.AbstractExtensionFactory;
+
+public abstract class CredentialProviderFactory<C> extends AbstractExtensionFactory<CredentialProvider, C> {
+	protected CredentialProviderFactory() {
+		super();
+	}
+
+	protected CredentialProviderFactory(Class<C> configClass) {
+		super(configClass);
+	}
+
+	@Override
+	public abstract CredentialProvider create(C config);
+
+	public String getName() {
+		return getShortName(CredentialProviderFactory.class);
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderService.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class CredentialProviderService {
+
 	private final ExtensionLocator<CredentialProvider> locator;
 
 	public CredentialProviderService(List<CredentialProviderFactory<?>> factories) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderService.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.CredentialProviderSpec;
+import org.springframework.cloud.appbroker.extensions.ExtensionLocator;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+
+public class CredentialProviderService {
+	private final ExtensionLocator<CredentialProvider> locator;
+
+	public CredentialProviderService(List<CredentialProviderFactory<?>> factories) {
+		locator = new ExtensionLocator<>(factories);
+	}
+
+	public Mono<List<BackingApplication>> addCredentials(List<BackingApplication> backingApplications,
+														 String serviceInstanceGuid) {
+		return Flux.fromIterable(backingApplications)
+			.flatMap(backingApplication -> {
+				List<CredentialProviderSpec> specs = getSpecsForApplication(backingApplication);
+
+				return Flux.fromIterable(specs)
+					.flatMap(spec -> {
+						CredentialProvider provider = locator.getByName(spec.getName(), spec.getArgs());
+						return provider.addCredentials(backingApplication, serviceInstanceGuid);
+					})
+					.then(Mono.just(backingApplication));
+			})
+			.collectList();
+	}
+
+	public Mono<List<BackingApplication>> deleteCredentials(List<BackingApplication> backingApplications,
+															String serviceInstanceGuid) {
+		return Flux.fromIterable(backingApplications)
+			.flatMap(backingApplication -> {
+				List<CredentialProviderSpec> specs = getSpecsForApplication(backingApplication);
+
+				return Flux.fromIterable(specs)
+					.flatMap(spec -> {
+						CredentialProvider provider = locator.getByName(spec.getName(), spec.getArgs());
+						return provider.deleteCredentials(backingApplication, serviceInstanceGuid);
+					})
+					.then(Mono.just(backingApplication));
+			})
+			.collectList();
+	}
+
+	private List<CredentialProviderSpec> getSpecsForApplication(BackingApplication backingApplication) {
+		return backingApplication.getParametersTransformers() == null
+			? Collections.emptyList()
+			: backingApplication.getCredentialProviders();
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGenerator.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.security.SecureRandom;
 
 public class SimpleCredentialGenerator implements CredentialGenerator {
+
 	private static final String UPPERCASE_ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	private static final String LOWERCASE_ALPHA = "abcdefghijklmnopqrstuvwxyz";
 	private static final String DIGITS = "0123456789";

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGenerator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.security.SecureRandom;
+
+public class SimpleCredentialGenerator implements CredentialGenerator {
+	private static final String UPPERCASE_ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+	private static final String LOWERCASE_ALPHA = "abcdefghijklmnopqrstuvwxyz";
+	private static final String DIGITS = "0123456789";
+	private static final String SPECIAL_CHARACTERS = "~`!@#$%^&*()-_=+[{]}\\|;:\'\",<.>/?";
+
+	private final SecureRandom secureRandom = new SecureRandom();
+	
+	@Override
+	public Pair<String, String> generateUser(String applicationId, String serviceInstanceId, int length,
+											 boolean includeUppercaseAlpha, boolean includeLowercaseAlpha,
+											 boolean includeNumeric, boolean includeSpecial) {
+		return Pair.of(
+			generateString(applicationId, serviceInstanceId, length,
+				includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric, includeSpecial),
+			generateString(applicationId, serviceInstanceId, length,
+				includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric, includeSpecial));
+	}
+
+	@Override
+	public String generateString(String applicationId, String serviceInstanceId, int length,
+								 boolean includeUppercaseAlpha, boolean includeLowercaseAlpha,
+								 boolean includeNumeric, boolean includeSpecial) {
+		StringBuilder builder = new StringBuilder();
+
+		if (includeUppercaseAlpha) {
+			builder.append(UPPERCASE_ALPHA);
+		}
+
+		if (includeLowercaseAlpha) {
+			builder.append(LOWERCASE_ALPHA);
+		}
+
+		if (includeNumeric) {
+			builder.append(DIGITS);
+		}
+
+		if (includeSpecial) {
+			builder.append(SPECIAL_CHARACTERS);
+		}
+
+		if (builder.toString().length() == 0) {
+			builder.append(UPPERCASE_ALPHA)
+				.append(LOWERCASE_ALPHA)
+				.append(DIGITS)
+				.append(SPECIAL_CHARACTERS);
+		}
+
+		char[] chars = builder.toString().toCharArray();
+
+		return RandomStringUtils.random(length, 0, chars.length - 1, false, false, chars, secureRandom);
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactory.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import reactor.core.publisher.Mono;
+
+public class SpringSecurityBasicAuthCredentialProviderFactory extends
+	CredentialProviderFactory<SpringSecurityBasicAuthCredentialProviderFactory.Config> {
+
+	static final String SPRING_SECURITY_USER_NAME = "security.user.name";
+	static final String SPRING_SECURITY_USER_PASSWORD = "security.user.password";
+
+	private CredentialGenerator credentialGenerator;
+
+	public SpringSecurityBasicAuthCredentialProviderFactory(CredentialGenerator credentialGenerator) {
+		super(Config.class);
+		this.credentialGenerator = credentialGenerator;
+	}
+
+	@Override
+	public CredentialProvider create(Config config) {
+		return new CredentialProvider() {
+			@Override
+			public Mono<BackingApplication> addCredentials(BackingApplication backingApplication,
+														   String serviceInstanceGuid) {
+				generateCredentials(config, backingApplication, serviceInstanceGuid);
+				return Mono.just(backingApplication);
+			}
+
+			@Override
+			public Mono<BackingApplication> deleteCredentials(BackingApplication backingApplication,
+															  String serviceInstanceGuid) {
+				credentialGenerator.deleteUser(backingApplication.getName(), serviceInstanceGuid);
+				return Mono.just(backingApplication);
+			}
+		};
+	}
+
+	private void generateCredentials(Config config,
+									 BackingApplication backingApplication,
+									 String serviceInstanceGuid) {
+		Pair<String, String> user =
+			credentialGenerator.generateUser(backingApplication.getName(), serviceInstanceGuid,
+				config.getLength(), config.isIncludeUppercaseAlpha(), config.isIncludeLowercaseAlpha(),
+				config.isIncludeNumeric(), config.isIncludeSpecial());
+
+		backingApplication.addEnvironment(SPRING_SECURITY_USER_NAME, user.getLeft());
+		backingApplication.addEnvironment(SPRING_SECURITY_USER_PASSWORD, user.getRight());
+	}
+
+	@SuppressWarnings("WeakerAccess")
+	public static class Config {
+		private int length;
+		private boolean includeUppercaseAlpha = true;
+		private boolean includeLowercaseAlpha = true;
+		private boolean includeNumeric = true;
+		private boolean includeSpecial = true;
+
+		public int getLength() {
+			return length;
+		}
+
+		public void setLength(int length) {
+			this.length = length;
+		}
+
+		public boolean isIncludeUppercaseAlpha() {
+			return includeUppercaseAlpha;
+		}
+
+		public void setIncludeUppercaseAlpha(boolean includeUppercaseAlpha) {
+			this.includeUppercaseAlpha = includeUppercaseAlpha;
+		}
+
+		public boolean isIncludeLowercaseAlpha() {
+			return includeLowercaseAlpha;
+		}
+
+		public void setIncludeLowercaseAlpha(boolean includeLowercaseAlpha) {
+			this.includeLowercaseAlpha = includeLowercaseAlpha;
+		}
+
+		public boolean isIncludeNumeric() {
+			return includeNumeric;
+		}
+
+		public void setIncludeNumeric(boolean includeNumeric) {
+			this.includeNumeric = includeNumeric;
+		}
+
+		public boolean isIncludeSpecial() {
+			return includeSpecial;
+		}
+
+		public void setIncludeSpecial(boolean includeSpecial) {
+			this.includeSpecial = includeSpecial;
+		}
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/EnvironmentMappingParametersTransformerFactory.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/EnvironmentMappingParametersTransformerFactory.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.appbroker.extensions.parameters;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -40,20 +39,16 @@ public class EnvironmentMappingParametersTransformerFactory extends
 	private Mono<BackingApplication> transform(BackingApplication backingApplication,
 											   Map<String, Object> parameters,
 											   List<String> include) {
-		final Map<String, String> environment = new HashMap<>();
-		final Map<String, String> backingAppEnvironment = backingApplication.getEnvironment();
-		if (backingAppEnvironment != null) {
-			environment.putAll(backingAppEnvironment);
-		}
 		if (parameters != null) {
 			parameters.keySet().stream()
 				.filter(include::contains)
-				.forEach(key -> environment.put(key, parameters.get(key).toString()));
+				.forEach(key -> backingApplication.addEnvironment(key, parameters.get(key).toString()));
 		}
-		backingApplication.setEnvironment(environment);
+
 		return Mono.just(backingApplication);
 	}
 
+	@SuppressWarnings("WeakerAccess")
 	public static class Config {
 		private String include;
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationService.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationService.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.appbroker.deployer.BackingApplication;
 import org.springframework.cloud.appbroker.deployer.ParametersTransformerSpec;
 
 public class ParametersTransformationService {
+
 	private final ExtensionLocator<ParametersTransformer> locator;
 
 	public ParametersTransformationService(List<ParametersTransformerFactory<?>> factories) {

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/ConfigurationBeanUtils.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/ConfigurationBeanUtils.java
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-package org.springframework.cloud.appbroker.extensions;
+package org.springframework.cloud.appbroker.extensions.support;
 
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.DefaultBeanIntrospector;
+import org.apache.commons.beanutils.SuppressPropertiesBeanIntrospector;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.support.AopUtils;
 
@@ -29,10 +32,18 @@ public abstract class ConfigurationBeanUtils {
 	}
 
 	public static <T> void populate(T targetObject, Map<String, Object> properties) {
+		if (properties == null) {
+			return;
+		}
+		
 		T target = getTargetObject(targetObject);
 
 		try {
-			org.apache.commons.beanutils.BeanUtils.populate(target, properties);
+			BeanUtilsBean beanUtils = new BeanUtilsBean();
+			beanUtils.getPropertyUtils().addBeanIntrospector(DefaultBeanIntrospector.INSTANCE);
+			beanUtils.getPropertyUtils().addBeanIntrospector(new KebabCasePropertyBeanIntrospector());
+			beanUtils.getPropertyUtils().addBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+			beanUtils.copyProperties(target, properties);
 		} catch (IllegalAccessException | InvocationTargetException e) {
 			throw new IllegalArgumentException("Failed to populate target of type " + targetObject.getClass()
 				+ " with properties " + properties, e);

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/KebabCasePropertyBeanIntrospector.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/KebabCasePropertyBeanIntrospector.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.appbroker.extensions.support;
+
+import org.apache.commons.beanutils.BeanIntrospector;
+import org.apache.commons.beanutils.DefaultBeanIntrospector;
+import org.apache.commons.beanutils.IntrospectionContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+/**
+ * <p>
+ * An implementation of the {@link BeanIntrospector} interface that provides property descriptors
+ * following the kebab-case convention.
+ * </p>
+ *
+ * This implementation is intended to collaborate with a {@link DefaultBeanIntrospector} object.
+ * Best results are achieved by adding this instance as custom {@link BeanIntrospector} after the
+ * {@link DefaultBeanIntrospector} object.
+ */
+public class KebabCasePropertyBeanIntrospector implements BeanIntrospector {
+	private static final String WRITE_METHOD_PREFIX = "set";
+
+	private final Log log = LogFactory.getLog(getClass());
+
+	/**
+	 * Creates a new instance of <code>KebabCaseBeanIntrospector</code> and
+	 * sets the default prefix for write methods.
+	 */
+	KebabCasePropertyBeanIntrospector() {
+	}
+
+	/**
+	 * Performs introspection. This method scans the current class's methods for
+	 * property write methods add adds a property descriptor using the kebab-case
+	 * naming convention to match each property descriptor that uses the camel-case
+	 * Java Bean convention.
+	 *
+	 * @param context the introspection context
+	 */
+	public void introspect(final IntrospectionContext context) {
+		for (final Method m : context.getTargetClass().getMethods()) {
+			if (m.getName().startsWith(WRITE_METHOD_PREFIX)) {
+				final String propertyName = camelCasePropertyName(m);
+				final PropertyDescriptor pd = context.getPropertyDescriptor(propertyName);
+				try {
+					if (pd != null) {
+						context.addPropertyDescriptor(createPropertyDescriptor(m));
+					}
+				} catch (final IntrospectionException e) {
+					log.info("Error when creating PropertyDescriptor for " + m
+						+ "! Ignoring this property.");
+					log.debug("Exception is:", e);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Derives the camel-case name of a property from the given set method.
+	 *
+	 * @param m the method
+	 * @return the corresponding property name
+	 */
+	private String camelCasePropertyName(final Method m) {
+		final String methodName = m.getName().substring(WRITE_METHOD_PREFIX.length());
+		return (methodName.length() > 1) ?
+			Introspector.decapitalize(methodName) :
+			methodName.toLowerCase(Locale.ENGLISH);
+	}
+
+	/**
+	 * Derives the kebab-case name of a property from the given set method.
+	 *
+	 * @param m the method
+	 * @return the corresponding property name
+	 */
+	private String kebabCasePropertyName(final Method m) {
+		final String methodName = camelCasePropertyName(m);
+		
+		StringBuilder builder = new StringBuilder();
+		for (char c : methodName.toCharArray()) {
+			if (Character.isUpperCase(c)) {
+				builder.append("-").append(Character.toLowerCase(c));
+			} else {
+				builder.append(c);
+			}
+		}
+		
+		return builder.toString();
+	}
+
+	/**
+	 * Creates a property descriptor for a property.
+	 *
+	 * @param m the set method for the property
+	 * @return the descriptor
+	 * @throws IntrospectionException if an error occurs
+	 */
+	private PropertyDescriptor createPropertyDescriptor(final Method m) throws IntrospectionException {
+		String propertyName = kebabCasePropertyName(m);
+		return new PropertyDescriptor(propertyName, null, m);
+	}
+}

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/KebabCasePropertyBeanIntrospector.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/support/KebabCasePropertyBeanIntrospector.java
@@ -38,6 +38,7 @@ import java.util.Locale;
  * {@link DefaultBeanIntrospector} object.
  */
 public class KebabCasePropertyBeanIntrospector implements BeanIntrospector {
+
 	private static final String WRITE_METHOD_PREFIX = "set";
 
 	private final Log log = LogFactory.getLog(getClass());

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflow.java
@@ -35,8 +35,8 @@ public class AppDeploymentUpdateServiceInstanceWorkflow
 	implements UpdateServiceInstanceWorkflow {
 	private final Logger log = Loggers.getLogger(AppDeploymentUpdateServiceInstanceWorkflow.class);
 
-	private BackingAppDeploymentService deploymentService;
-	private ParametersTransformationService parametersTransformationService;
+	private final BackingAppDeploymentService deploymentService;
+	private final ParametersTransformationService parametersTransformationService;
 
 	public AppDeploymentUpdateServiceInstanceWorkflow(BrokeredServices brokeredServices,
 													  BackingAppDeploymentService deploymentService,
@@ -48,7 +48,8 @@ public class AppDeploymentUpdateServiceInstanceWorkflow
 
 	public Flux<Void> update(UpdateServiceInstanceRequest request) {
 		return getBackingApplicationsForService(request.getServiceDefinition(), request.getPlanId())
-			.flatMap(backingApps -> parametersTransformationService.transformParameters(backingApps, request.getParameters()))
+			.flatMap(backingApps ->
+				parametersTransformationService.transformParameters(backingApps, request.getParameters()))
 			.flatMapMany(deploymentService::deploy)
 			.doOnRequest(l -> log.info("Deploying applications {}", brokeredServices))
 			.doOnEach(s -> log.info("Finished deploying {}", s))

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/ConfigurationBeanUtilsTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/ConfigurationBeanUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationBeanUtilsTest {
+	
 	private TestProperties targetObject = new TestProperties();
 	private Map<String, Object> properties = new HashMap<>();
 

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/ConfigurationBeanUtilsTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/ConfigurationBeanUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.appbroker.extensions.support.ConfigurationBeanUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConfigurationBeanUtilsTest {
+	private TestProperties targetObject = new TestProperties();
+	private Map<String, Object> properties = new HashMap<>();
+
+	@Test
+	void populateWithCamelCaseProperties() {
+		properties.put("stringValue", "value");
+		properties.put("intValue", 41);
+		properties.put("booleanValue", true);
+
+		ConfigurationBeanUtils.populate(targetObject, properties);
+
+		assertValuesPopulated(targetObject);
+	}
+
+	@Test
+	void populateWithKebabCaseProperties() {
+		properties.put("string-value", "value");
+		properties.put("int-value", 41);
+		properties.put("boolean-value", true);
+
+		ConfigurationBeanUtils.populate(targetObject, properties);
+
+		assertValuesPopulated(targetObject);
+	}
+
+	@Test
+	void populateWithEmptyProperties() {
+		ConfigurationBeanUtils.populate(targetObject, properties);
+
+		assertValuesNotPopulated(targetObject);
+	}
+
+	@Test
+	void populateWithNullProperties() {
+		ConfigurationBeanUtils.populate(targetObject, null);
+
+		assertValuesNotPopulated(targetObject);
+	}
+
+	private void assertValuesPopulated(TestProperties targetObject) {
+		assertThat(targetObject.getStringValue()).isEqualTo("value");
+		assertThat(targetObject.getIntValue()).isEqualTo(41);
+		assertThat(targetObject.getBooleanValue()).isEqualTo(true);
+	}
+
+	private void assertValuesNotPopulated(TestProperties targetObject) {
+		assertThat(targetObject.getStringValue()).isNull();
+		assertThat(targetObject.getIntValue()).isEqualTo(0);
+		assertThat(targetObject.getBooleanValue()).isEqualTo(false);
+	}
+
+	@SuppressWarnings("unused")
+	public static class TestProperties {
+		private String stringValue;
+		private int intValue;
+		private boolean booleanValue;
+
+		String getStringValue() {
+			return stringValue;
+		}
+
+		public void setStringValue(String stringValue) {
+			this.stringValue = stringValue;
+		}
+
+		int getIntValue() {
+			return intValue;
+		}
+
+		public void setIntValue(int intValue) {
+			this.intValue = intValue;
+		}
+
+		boolean getBooleanValue() {
+			return booleanValue;
+		}
+
+		public void setBooleanValue(boolean booleanValue) {
+			this.booleanValue = booleanValue;
+		}
+	}
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import org.springframework.cloud.appbroker.deployer.BackingApplications;
+import org.springframework.cloud.appbroker.deployer.CredentialProviderSpec;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CredentialProviderServiceTest {
+	@Test
+	void addAndDeleteCredentials() {
+		BackingApplication app1 = BackingApplication.builder()
+			.name("app1")
+			.credentialProviders(CredentialProviderSpec.builder()
+				.name("provider1")
+				.build())
+			.build();
+		BackingApplication app2 = BackingApplication.builder()
+			.name("app2")
+			.credentialProviders(CredentialProviderSpec.builder()
+					.name("provider1")
+					.build(),
+				CredentialProviderSpec.builder()
+					.name("provider2")
+					.build())
+			.build();
+		BackingApplications backingApplications = BackingApplications.builder()
+			.backingApplication(app1)
+			.backingApplication(app2)
+			.build();
+
+		TestFactory factory1 = new TestFactory("provider1");
+		TestFactory factory2 = new TestFactory("provider2");
+
+		CredentialProviderService service = new CredentialProviderService(Arrays.asList(factory1, factory2));
+
+		StepVerifier
+			.create(service.addCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+
+		StepVerifier
+			.create(service.deleteCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+
+		assertThat(app1.getEnvironment()).containsKey("provider1-added");
+		assertThat(app1.getEnvironment()).containsKey("provider1-deleted");
+		assertThat(app1.getEnvironment()).doesNotContainKey("provider2-added");
+		assertThat(app1.getEnvironment()).doesNotContainKey("provider2-deleted");
+
+		assertThat(app2.getEnvironment()).containsKey("provider1-added");
+		assertThat(app2.getEnvironment()).containsKey("provider1-deleted");
+		assertThat(app2.getEnvironment()).containsKey("provider2-added");
+		assertThat(app2.getEnvironment()).containsKey("provider2-deleted");
+	}
+
+	@Test
+	void addAndDeleteCredentialsWithNoBackingApps() {
+		CredentialProviderService service = new CredentialProviderService(Collections.emptyList());
+
+		BackingApplications backingApplications = BackingApplications.builder()
+			.build();
+
+		StepVerifier
+			.create(service.addCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+
+		StepVerifier
+			.create(service.deleteCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+	}
+
+	@Test
+	void addAndDeleteCredentialsWithNoProviders() {
+		CredentialProviderService service = new CredentialProviderService(Collections.emptyList());
+
+		BackingApplications backingApplications = BackingApplications.builder()
+			.backingApplication(BackingApplication.builder().build())
+			.build();
+
+		StepVerifier
+			.create(service.addCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+
+		StepVerifier
+			.create(service.deleteCredentials(backingApplications, "service-instance-guid"))
+			.expectNext(backingApplications)
+			.verifyComplete();
+	}
+
+	public class TestFactory extends CredentialProviderFactory<Object> {
+		private String name;
+
+		TestFactory(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String getName() {
+			return this.name;
+		}
+
+		@Override
+		public CredentialProvider create(Object config) {
+			return new CredentialProvider() {
+				@Override
+				public Mono<BackingApplication> addCredentials(BackingApplication backingApplication, String serviceInstanceGuid) {
+					backingApplication.addEnvironment(name + "-added", "done");
+					return Mono.just(backingApplication);
+				}
+
+				@Override
+				public Mono<BackingApplication> deleteCredentials(BackingApplication backingApplication, String serviceInstanceGuid) {
+					backingApplication.addEnvironment(name + "-deleted", "done");
+					return Mono.just(backingApplication);
+				}
+			};
+		}
+	}
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialProviderServiceTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CredentialProviderServiceTest {
+
 	@Test
 	void addAndDeleteCredentials() {
 		BackingApplication app1 = BackingApplication.builder()

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SimpleCredentialGeneratorTest {
+	@Test
+	void generateString() {
+		SimpleCredentialGenerator generator = new SimpleCredentialGenerator();
+
+		assertThat(generator.generateString(null, null, 12, true, false, false, false))
+			.matches("^[A-Z]{12}$");
+		assertThat(generator.generateString(null, null, 12, false, true, false, false))
+			.matches("^[a-z]{12}$");
+		assertThat(generator.generateString(null, null, 12, false, false, true, false))
+			.matches("^[0-9]{12}$");
+		assertThat(generator.generateString(null, null, 12, false, false, false, true))
+			.matches("^[\\p{Punct}]{12}$");
+
+		assertThat(generator.generateString(null, null, 12, true, true, true, true))
+			.matches("^[a-zA-Z0-9\\p{Punct}]{12}$");
+		assertThat(generator.generateString(null, null, 12, false, false, false, false))
+			.matches("^[a-zA-Z0-9\\p{Punct}]{12}$");
+	}
+
+	@Test
+	void generateUser() {
+		SimpleCredentialGenerator generator = new SimpleCredentialGenerator();
+
+		Pair<String, String> user = generator.generateUser(null, null, 10, true, true, true, true);
+
+		assertThat(user.getLeft().length()).isEqualTo(10);
+		assertThat(user.getRight().length()).isEqualTo(10);
+	}
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SimpleCredentialGeneratorTest {
+
 	@Test
 	void generateString() {
 		SimpleCredentialGenerator generator = new SimpleCredentialGenerator();

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactoryTest.java
@@ -34,6 +34,7 @@ import static org.springframework.cloud.appbroker.extensions.credentials.SpringS
 
 @ExtendWith(MockitoExtension.class)
 class SpringSecurityBasicAuthCredentialProviderFactoryTest {
+
 	@Mock
 	private CredentialGenerator credentialGenerator;
 

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityBasicAuthCredentialProviderFactoryTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.appbroker.deployer.BackingApplication;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.appbroker.extensions.credentials.SpringSecurityBasicAuthCredentialProviderFactory.SPRING_SECURITY_USER_NAME;
+import static org.springframework.cloud.appbroker.extensions.credentials.SpringSecurityBasicAuthCredentialProviderFactory.SPRING_SECURITY_USER_PASSWORD;
+
+@ExtendWith(MockitoExtension.class)
+class SpringSecurityBasicAuthCredentialProviderFactoryTest {
+	@Mock
+	private CredentialGenerator credentialGenerator;
+
+	private CredentialProvider provider;
+
+	@BeforeEach
+	void setUp() {
+		provider = new SpringSecurityBasicAuthCredentialProviderFactory(credentialGenerator)
+			.createWithConfig(config -> {
+				config.setLength(8);
+				config.setIncludeUppercaseAlpha(true);
+				config.setIncludeLowercaseAlpha(false);
+				config.setIncludeNumeric(true);
+				config.setIncludeSpecial(false);
+			});
+	}
+
+	@Test
+	void addCredentials() {
+		BackingApplication backingApplication = BackingApplication.builder()
+			.build();
+
+		when(credentialGenerator.generateUser(backingApplication.getName(), "service-instance-id",
+			8, true, false, true, false))
+			.thenReturn(Pair.of("username", "password"));
+
+		StepVerifier
+			.create(provider.addCredentials(backingApplication, "service-instance-id"))
+			.expectNext(backingApplication)
+			.verifyComplete();
+
+		assertThat(backingApplication.getEnvironment()).containsEntry(SPRING_SECURITY_USER_NAME, "username");
+		assertThat(backingApplication.getEnvironment()).containsEntry(SPRING_SECURITY_USER_PASSWORD, "password");
+	}
+
+	@Test
+	void deleteCredentials() {
+		BackingApplication backingApplication = BackingApplication.builder()
+			.build();
+
+		StepVerifier
+			.create(provider.deleteCredentials(backingApplication, "service-instance-id"))
+			.expectNext(backingApplication)
+			.verifyComplete();
+
+		verify(credentialGenerator).deleteUser(backingApplication.getName(), "service-instance-id");
+		verifyNoMoreInteractions(credentialGenerator);
+	}
+}

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/EnvironmentMappingParametersTransformerFactoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/EnvironmentMappingParametersTransformerFactoryTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EnvironmentMappingParametersTransformerFactoryTest {
+
 	private ParametersTransformer transformer;
 
 	@BeforeEach

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class ParametersTransformationServiceTest {
+
 	@Test
 	void transformParametersWithNoBackingApps() {
 		ParametersTransformationService service = new ParametersTransformationService(Collections.emptyList());

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformationServiceTest.java
@@ -169,7 +169,7 @@ class ParametersTransformationServiceTest {
 		private Mono<BackingApplication> doTransform(BackingApplication backingApplication,
 													 Map<String, Object> parameters) {
 			this.actualParameters = parameters;
-			backingApplication.getEnvironment().put(Integer.toString(backingApplication.getEnvironment().size()), getName());
+			backingApplication.addEnvironment(Integer.toString(backingApplication.getEnvironment().size()), getName());
 			return Mono.just(backingApplication);
 		}
 
@@ -177,11 +177,12 @@ class ParametersTransformationServiceTest {
 			return actualParameters;
 		}
 
-		public Config getActualConfig() {
+		Config getActualConfig() {
 			return actualConfig;
 		}
 	}
 
+	@SuppressWarnings("unused")
 	public static class Config {
 		private String arg1;
 		private Integer arg2;

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentCreateServiceInstanceWorkflowTest.java
@@ -23,9 +23,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.cloud.appbroker.deployer.BrokeredService;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
+import org.springframework.cloud.appbroker.extensions.credentials.CredentialProviderService;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceWorkflow;
-import org.springframework.cloud.servicebroker.exception.ServiceBrokerException;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest;
@@ -53,6 +53,9 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 
 	@Mock
 	private ParametersTransformationService parametersTransformationService;
+
+	@Mock
+	private CredentialProviderService credentialProviderService;
 
 	private BackingApplications backingApps;
 
@@ -82,7 +85,8 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 		createServiceInstanceWorkflow = new AppDeploymentCreateServiceInstanceWorkflow(
 			brokeredServices,
 			backingAppDeploymentService,
-			parametersTransformationService);
+			parametersTransformationService,
+			credentialProviderService);
 	}
 
 	@Test
@@ -94,6 +98,8 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 			.willReturn(Flux.just("app1", "app2"));
 		given(this.parametersTransformationService.transformParameters(eq(backingApps), eq(request.getParameters())))
 			.willReturn(Mono.just(backingApps));
+		given(this.credentialProviderService.addCredentials(eq(backingApps), eq(request.getServiceInstanceId())))
+			.willReturn(Mono.just(backingApps));
 
 		StepVerifier
 			.create(createServiceInstanceWorkflow.create(request))
@@ -103,6 +109,7 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.credentialProviderService);
 	}
 
 	@Test
@@ -114,6 +121,8 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 			.willReturn(Flux.just("app1", "app2"));
 		given(this.parametersTransformationService.transformParameters(eq(backingApps), eq(request.getParameters())))
 			.willReturn(Mono.just(backingApps));
+		given(this.credentialProviderService.addCredentials(eq(backingApps), eq(request.getServiceInstanceId())))
+			.willReturn(Mono.just(backingApps));
 
 		StepVerifier
 			.create(createServiceInstanceWorkflow.create(request))
@@ -123,6 +132,7 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.credentialProviderService);
 	}
 
 	@Test
@@ -135,6 +145,7 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.credentialProviderService);
 	}
 
 	private CreateServiceInstanceRequest buildRequest(String serviceName, String planName) {
@@ -146,6 +157,7 @@ class AppDeploymentCreateServiceInstanceWorkflowTest {
 		return CreateServiceInstanceRequest.builder()
 			.serviceDefinitionId(serviceName + "-id")
 			.planId(planName + "-id")
+			.serviceInstanceId(serviceName + "-" + planName + "-instance-id")
 			.serviceDefinition(ServiceDefinition.builder()
 				.id(serviceName + "-id")
 				.name(serviceName)

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
@@ -78,7 +78,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 		updateServiceInstanceWorkflow = new AppDeploymentUpdateServiceInstanceWorkflow(brokeredServices,
 			backingAppDeploymentService,
-			parametersTransformationService);
+			parametersTransformationService
+		);
 	}
 
 	@Test
@@ -140,6 +141,7 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 		return UpdateServiceInstanceRequest.builder()
 			.serviceDefinitionId(serviceName + "-id")
 			.planId(planName + "-id")
+			.serviceInstanceId(serviceName + "-" + planName + "-instance-id")
 			.serviceDefinition(ServiceDefinition.builder()
 				.id(serviceName + "-id")
 				.name(serviceName)

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceComponentTest.java
@@ -40,6 +40,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceComponent
 	"spring.cloud.appbroker.services[0].apps[1].name=" + APP_NAME_2
 })
 class CreateInstanceComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME_1 = "first-app";
 	static final String APP_NAME_2 = "second-app";
 

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCreationParametersComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCreationParametersComponentTest.java
@@ -46,6 +46,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithCreat
 	"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].args.include=parameter1,parameter2"
 })
 class CreateInstanceWithCreationParametersComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-env-create-params";
 
 	@Autowired

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCredentialsComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCredentialsComponentTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.sample;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.appbroker.sample.fixtures.CloudControllerStubFixture;
+import org.springframework.cloud.appbroker.sample.fixtures.OpenServiceBrokerApiFixture;
+import org.springframework.cloud.servicebroker.model.instance.OperationState;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.cloud.appbroker.sample.CreateInstanceWithCredentialsComponentTest.APP_NAME;
+
+@TestPropertySource(properties = {
+	"spring.cloud.appbroker.services[0].service-name=example",
+	"spring.cloud.appbroker.services[0].plan-name=standard",
+	"spring.cloud.appbroker.services[0].apps[0].path=classpath:demo.jar",
+	"spring.cloud.appbroker.services[0].apps[0].name=" + APP_NAME,
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].name=SpringSecurityBasicAuth",
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.length=14",
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.include-uppercase-alpha=true",
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.include-lowercase-alpha=true",
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.include-numeric=false",
+	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.include-special=false"
+})
+class CreateInstanceWithCredentialsComponentTest extends WiremockComponentTest {
+	static final String APP_NAME = "app-with-credentials";
+
+	@Autowired
+	private OpenServiceBrokerApiFixture brokerFixture;
+
+	@Autowired
+	private CloudControllerStubFixture cloudControllerFixture;
+
+	@Test
+	void pushAppWithEnvironmentVariables() {
+		cloudControllerFixture.stubAppDoesNotExist(APP_NAME);
+		cloudControllerFixture.stubPushApp(APP_NAME,
+			matchingJsonPath("$.environment_json[?(@.SPRING_APPLICATION_JSON =~ /.*security.user.name.*:.*[a-zA-Z]{14}.*/)]"),
+			matchingJsonPath("$.environment_json[?(@.SPRING_APPLICATION_JSON =~ /.*security.user.password.*:.*[a-zA-Z]{14}.*/)]"));
+
+		// when a service instance is created
+		given(brokerFixture.serviceInstanceRequest())
+			.when()
+			.put(brokerFixture.createServiceInstanceUrl(), "instance-id")
+			.then()
+			.statusCode(HttpStatus.ACCEPTED.value());
+
+		// when the "last_operation" API is polled
+		given(brokerFixture.serviceInstanceRequest())
+			.when()
+			.get(brokerFixture.getLastInstanceOperationUrl(), "instance-id")
+			.then()
+			.statusCode(HttpStatus.OK.value())
+			.body("state", is(equalTo(OperationState.IN_PROGRESS.toString())));
+
+		String state = brokerFixture.waitForAsyncOperationComplete("instance-id");
+		assertThat(state).isEqualTo(OperationState.SUCCEEDED.toString());
+	}
+}

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCredentialsComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCredentialsComponentTest.java
@@ -44,6 +44,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithCrede
 	"spring.cloud.appbroker.services[0].apps[0].credential-providers[0].args.include-special=false"
 })
 class CreateInstanceWithCredentialsComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-credentials";
 
 	@Autowired

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCustomCreationParametersComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithCustomCreationParametersComponentTest.java
@@ -53,6 +53,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithCusto
 })
 @ContextConfiguration(classes = CreateInstanceWithCustomCreationParametersComponentTest.CustomConfig.class)
 class CreateInstanceWithCustomCreationParametersComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-request-create-params";
 
 	@Autowired

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithEnvironmentComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithEnvironmentComponentTest.java
@@ -40,6 +40,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithEnvir
 	"spring.cloud.appbroker.services[0].apps[0].environment.ENV_VAR_2=true",
 })
 class CreateInstanceWithEnvironmentComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-env";
 
 	@Autowired

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithPropertiesComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithPropertiesComponentTest.java
@@ -41,6 +41,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithPrope
 	"spring.cloud.appbroker.services[0].apps[0].properties.health-check-timeout=180"
 })
 class CreateInstanceWithPropertiesComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-properties";
 
 	@Autowired

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithServicesComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/CreateInstanceWithServicesComponentTest.java
@@ -42,6 +42,7 @@ import static org.springframework.cloud.appbroker.sample.CreateInstanceWithServi
 	"spring.cloud.appbroker.services[0].apps[0].services[1]=" + SERVICE_INSTANCE_2_NAME
 })
 class CreateInstanceWithServicesComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME = "app-with-services";
 
 	static final String SERVICE_INSTANCE_1_NAME = "my-db-service";

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/DeleteInstanceComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/DeleteInstanceComponentTest.java
@@ -41,6 +41,7 @@ import static org.springframework.cloud.appbroker.sample.DeleteInstanceComponent
 	"spring.cloud.appbroker.services[0].apps[1].name=" + APP_NAME_2
 })
 class DeleteInstanceComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME_1 = "first-app";
 	static final String APP_NAME_2 = "second-app";
 

--- a/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/UpdateInstanceComponentTest.java
+++ b/spring-cloud-app-broker-sample/src/test/java/org.springframework.cloud.appbroker/sample/UpdateInstanceComponentTest.java
@@ -40,6 +40,7 @@ import static org.springframework.cloud.appbroker.sample.UpdateInstanceComponent
 	"spring.cloud.appbroker.services[0].apps[1].name=" + APP_NAME_2
 })
 class UpdateInstanceComponentTest extends WiremockComponentTest {
+
 	static final String APP_NAME_1 = "first-app";
 	static final String APP_NAME_2 = "second-app";
 


### PR DESCRIPTION
This includes a `CredentialGenerator` interface to encapsulate the responsibility of generating and storing credentials to be used by `CredentialProvider`s. A `SimpleCredentialGenerator` implementation is provided that generates credentials internally and does not store them. Supporting CredHub or other external secret management services *should* involve providing an alternate `CredentialGenerator` implementation and adding it to the application context. 

