### PR TITLE
Fixing update flow with SpacePerServiceInstance

### DIFF
--- a/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceAcceptanceTest.java
+++ b/spring-cloud-app-broker-acceptance-tests/src/test/java/org.springframework.cloud.appbroker.acceptance/UpdateInstanceAcceptanceTest.java
@@ -42,6 +42,7 @@ class UpdateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		"spring.cloud.appbroker.services[0].apps[0].environment.parameter1=config1",
 		"spring.cloud.appbroker.services[0].apps[0].environment.parameter2=config2",
 		"spring.cloud.appbroker.services[0].apps[0].environment.parameter3=config3",
+		"spring.cloud.appbroker.services[0].apps[0].environment.parameter4=config4",
 		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].name=EnvironmentMapping",
 		"spring.cloud.appbroker.services[0].apps[0].parameters-transformers[0].args.include=parameter1,parameter3"
 	})
@@ -76,6 +77,11 @@ class UpdateInstanceAcceptanceTest extends CloudFoundryAcceptanceTest {
 		assertThat(applicationEnvironments.getUserProvided().get("SPRING_APPLICATION_JSON")).asString()
 			.contains("\"parameter1\":\"value1\"")
 			.contains("\"parameter2\":\"config2\"")
-			.contains("\"parameter3\":\"value3\"");
+			.contains("\"parameter3\":\"value3\"")
+			.contains("\"parameter4\":\"config4\"");
+
+		// and the backing application contains the initial parameters
+		assertThat(applicationEnvironments.getUserProvided().get("SPRING_APPLICATION_JSON")).asString()
+			.contains("\"parameter4\":\"config4\"");
 	}
 }

--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfiguration.java
@@ -139,8 +139,9 @@ public class AppBrokerAutoConfiguration {
 	@Bean
 	public UpdateServiceInstanceWorkflow updateServiceInstanceWorkflow(BrokeredServices brokeredServices,
 																	   BackingAppDeploymentService backingAppDeploymentService,
-																	   ParametersTransformationService parametersTransformationService) {
-		return new AppDeploymentUpdateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService);
+																	   ParametersTransformationService parametersTransformationService,
+																	   TargetService targetService) {
+		return new AppDeploymentUpdateServiceInstanceWorkflow(brokeredServices, backingAppDeploymentService, parametersTransformationService, targetService);
 	}
 
 	@Bean

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/workflow/instance/AppDeploymentUpdateServiceInstanceWorkflowTest.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.appbroker.deployer.BackingApplications;
 import org.springframework.cloud.appbroker.deployer.BrokeredService;
 import org.springframework.cloud.appbroker.deployer.BrokeredServices;
 import org.springframework.cloud.appbroker.extensions.parameters.ParametersTransformationService;
+import org.springframework.cloud.appbroker.extensions.targets.TargetService;
 import org.springframework.cloud.servicebroker.model.catalog.Plan;
 import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition;
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest;
@@ -51,6 +52,9 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 	@Mock
 	private ParametersTransformationService parametersTransformationService;
+
+	@Mock
+	private TargetService targetService;
 
 	private BackingApplications backingApps;
 	private AppDeploymentUpdateServiceInstanceWorkflow updateServiceInstanceWorkflow;
@@ -78,10 +82,11 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 									.build())
 			.build();
 
-		updateServiceInstanceWorkflow = new AppDeploymentUpdateServiceInstanceWorkflow(
-			brokeredServices,
+		updateServiceInstanceWorkflow = new AppDeploymentUpdateServiceInstanceWorkflow(brokeredServices,
 			backingAppDeploymentService,
-			parametersTransformationService);
+			parametersTransformationService,
+			targetService)
+		;
 	}
 
 	@Test
@@ -91,6 +96,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 		given(this.backingAppDeploymentService.deploy(eq(backingApps)))
 			.willReturn(Flux.just("app1", "app2"));
+		given(this.targetService.add(eq(backingApps), eq("service-instance-id")))
+			.willReturn(Mono.just(backingApps));
 		given(this.parametersTransformationService.transformParameters(eq(backingApps), eq(request.getParameters())))
 			.willReturn(Mono.just(backingApps));
 
@@ -102,6 +109,7 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.targetService);
 	}
 
 	@Test
@@ -113,6 +121,8 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 			.willReturn(Flux.just("app1", "app2"));
 		given(this.parametersTransformationService.transformParameters(eq(backingApps), eq(request.getParameters())))
 			.willReturn(Mono.just(backingApps));
+		given(this.targetService.add(eq(backingApps), eq("service-instance-id")))
+			.willReturn(Mono.just(backingApps));
 
 		StepVerifier
 			.create(updateServiceInstanceWorkflow.update(request))
@@ -122,6 +132,7 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.targetService);
 	}
 
 	@Test
@@ -132,6 +143,7 @@ class AppDeploymentUpdateServiceInstanceWorkflowTest {
 
 		verifyNoMoreInteractions(this.backingAppDeploymentService);
 		verifyNoMoreInteractions(this.parametersTransformationService);
+		verifyNoMoreInteractions(this.targetService);
 	}
 
 	private UpdateServiceInstanceRequest buildRequest(String serviceName, String planName) {


### PR DESCRIPTION
Added TargetService to update flow
Added explicit assertion on backing app containin initial parameters afer an update
Updated AT to consider Updates with Target
Added ATs for multiple apps
Not failing when CF returns a DB error when creating a space
Not failing when space does not exist

Connected to #93