### PR TITLE
Add support to optionally generate secrets from CredHub

### DIFF
--- a/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfiguration.java
+++ b/spring-cloud-app-broker-autoconfigure/src/main/java/org/springframework/cloud/appbroker/autoconfigure/CredHubAutoConfiguration.java
@@ -16,27 +16,32 @@
 
 package org.springframework.cloud.appbroker.autoconfigure;
 
-import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingCreateServiceInstanceAppBindingWorkflow;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cloud.appbroker.extensions.credentials.CredHubCredentialsGenerator;
 import org.springframework.cloud.appbroker.service.CreateServiceInstanceAppBindingWorkflow;
+import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingCreateServiceInstanceAppBindingWorkflow;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.credhub.core.ReactiveCredHubOperations;
 
 @Configuration
 @AutoConfigureBefore(AppBrokerAutoConfiguration.class)
+@ConditionalOnBean(ReactiveCredHubOperations.class)
 public class CredHubAutoConfiguration {
 
 	@Value("${spring.application.name}")
 	private String appName;
 
 	@Bean
-	@ConditionalOnBean(ReactiveCredHubOperations.class)
 	public CreateServiceInstanceAppBindingWorkflow credhubPersistingCreateServiceInstanceAppBindingWorkflow(ReactiveCredHubOperations credHubOperations) {
 		return new CredHubPersistingCreateServiceInstanceAppBindingWorkflow(credHubOperations, appName);
+	}
+
+	@Bean
+	public CredHubCredentialsGenerator credHubCredentialsGenerator(ReactiveCredHubOperations credHubOperations) {
+		return new CredHubCredentialsGenerator(credHubOperations);
 	}
 
 }

--- a/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
+++ b/spring-cloud-app-broker-autoconfigure/src/test/java/org/springframework/cloud/appbroker/autoconfigure/AppBrokerAutoConfigurationTest.java
@@ -17,6 +17,10 @@
 package org.springframework.cloud.appbroker.autoconfigure;
 
 import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.appbroker.extensions.credentials.CredHubCredentialsGenerator;
+import org.springframework.cloud.appbroker.extensions.credentials.CredentialGenerator;
+import org.springframework.cloud.appbroker.extensions.credentials.SimpleCredentialGenerator;
 import org.springframework.cloud.appbroker.workflow.binding.CredHubPersistingCreateServiceInstanceAppBindingWorkflow;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -60,7 +64,14 @@ class AppBrokerAutoConfigurationTest {
 	@Test
 	void servicesAreCreatedWithCloudFoundryConfigured() {
 		configuredContext()
-			.run(this::assertContext);
+			.run(context -> {
+				assertContext(context);
+				assertThat(context).doesNotHaveBean(CreateServiceInstanceAppBindingWorkflow.class);
+				assertThat(context)
+					.hasSingleBean(CredentialGenerator.class)
+					.getBean(CredentialGenerator.class)
+					.isExactlyInstanceOf(SimpleCredentialGenerator.class);
+			});
 	}
 
 	@Test
@@ -73,6 +84,10 @@ class AppBrokerAutoConfigurationTest {
 					.hasSingleBean(CreateServiceInstanceAppBindingWorkflow.class)
 					.getBean(CreateServiceInstanceAppBindingWorkflow.class)
 					.isExactlyInstanceOf(CredHubPersistingCreateServiceInstanceAppBindingWorkflow.class);
+				assertThat(context)
+					.hasSingleBean(CredentialGenerator.class)
+					.getBean(CredentialGenerator.class)
+					.isExactlyInstanceOf(CredHubCredentialsGenerator.class);
 			});
 	}
 

--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredentialGenerator.java
@@ -16,23 +16,26 @@
 
 package org.springframework.cloud.appbroker.extensions.credentials;
 
-import org.apache.commons.lang3.tuple.Pair;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
 
 public interface CredentialGenerator {
 
-	Pair<String, String> generateUser(String applicationId, String serviceInstanceId,
-									  int length, boolean includeUppercaseAlpha,
-									  boolean includeLowercaseAlpha, boolean includeNumeric,
-									  boolean includeSpecial);
+	Mono<Tuple2<String, String>> generateUser(String applicationId, String serviceInstanceId, String descriptor,
+												   int length, boolean includeUppercaseAlpha,
+												   boolean includeLowercaseAlpha, boolean includeNumeric,
+												   boolean includeSpecial);
 
-	String generateString(String applicationId, String serviceInstanceId,
-						  int length, boolean includeUppercaseAlpha,
-						  boolean includeLowercaseAlpha, boolean includeNumeric,
-						  boolean includeSpecial);
+	Mono<String> generateString(String applicationId, String serviceInstanceId, String descriptor,
+								int length, boolean includeUppercaseAlpha,
+								boolean includeLowercaseAlpha, boolean includeNumeric,
+								boolean includeSpecial);
 
-	default void deleteUser(String applicationId, String serviceInstanceId) {
+	default Mono<Void> deleteUser(String applicationId, String serviceInstanceId, String descriptor) {
+		return Mono.empty();
 	}
 
-	default void deleteString(String applicationId, String serviceInstanceId) {
+	default Mono<Void> deleteString(String applicationId, String serviceInstanceId, String descriptor) {
+		return Mono.empty();
 	}
 }

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SimpleCredentialGeneratorTest.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.appbroker.extensions.credentials;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,28 +27,40 @@ class SimpleCredentialGeneratorTest {
 	void generateString() {
 		SimpleCredentialGenerator generator = new SimpleCredentialGenerator();
 
-		assertThat(generator.generateString(null, null, 12, true, false, false, false))
-			.matches("^[A-Z]{12}$");
-		assertThat(generator.generateString(null, null, 12, false, true, false, false))
-			.matches("^[a-z]{12}$");
-		assertThat(generator.generateString(null, null, 12, false, false, true, false))
-			.matches("^[0-9]{12}$");
-		assertThat(generator.generateString(null, null, 12, false, false, false, true))
-			.matches("^[\\p{Punct}]{12}$");
+		StepVerifier.create(generator.generateString(null, null, null, 12, true, false, false, false))
+					.assertNext(s -> assertThat(s).matches("^[A-Z]{12}$"))
+					.verifyComplete();
 
-		assertThat(generator.generateString(null, null, 12, true, true, true, true))
-			.matches("^[a-zA-Z0-9\\p{Punct}]{12}$");
-		assertThat(generator.generateString(null, null, 12, false, false, false, false))
-			.matches("^[a-zA-Z0-9\\p{Punct}]{12}$");
+		StepVerifier.create(generator.generateString(null, null, null, 12, false, true, false, false))
+					.assertNext(s -> assertThat(s).matches("^[a-z]{12}$"))
+					.verifyComplete();
+
+		StepVerifier.create(generator.generateString(null, null, null, 12, false, false, true, false))
+					.assertNext(s -> assertThat(s).matches("^[0-9]{12}$"))
+					.verifyComplete();
+
+		StepVerifier.create(generator.generateString(null, null, null, 12, false, false, false, true))
+					.assertNext(s -> assertThat(s).matches("^[\\p{Punct}]{12}$"))
+					.verifyComplete();
+
+		StepVerifier.create(generator.generateString(null, null, null, 12, true, true, true, true))
+					.assertNext(s -> assertThat(s).matches("^[a-zA-Z0-9\\p{Punct}]{12}$"))
+					.verifyComplete();
+
+		StepVerifier.create(generator.generateString(null, null, null, 12, false, false, false, false))
+					.assertNext(s -> assertThat(s).matches("^[a-zA-Z0-9\\p{Punct}]{12}$"))
+					.verifyComplete();
 	}
 
 	@Test
 	void generateUser() {
 		SimpleCredentialGenerator generator = new SimpleCredentialGenerator();
 
-		Pair<String, String> user = generator.generateUser(null, null, 10, true, true, true, true);
-
-		assertThat(user.getLeft().length()).isEqualTo(10);
-		assertThat(user.getRight().length()).isEqualTo(10);
+		StepVerifier.create(generator.generateUser(null, null, null, 10, true, true, true, true))
+					.assertNext(user -> {
+						assertThat(user.getT1().length()).isEqualTo(10);
+						assertThat(user.getT2().length()).isEqualTo(10);
+					})
+					.verifyComplete();
 	}
 }

--- a/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityOAuth2CredentialProviderFactoryTest.java
+++ b/spring-cloud-app-broker-core/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/SpringSecurityOAuth2CredentialProviderFactoryTest.java
@@ -16,23 +16,25 @@
 
 package org.springframework.cloud.appbroker.extensions.credentials;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
 import org.springframework.cloud.appbroker.deployer.BackingApplication;
 import org.springframework.cloud.appbroker.oauth2.CreateOAuth2ClientRequest;
 import org.springframework.cloud.appbroker.oauth2.CreateOAuth2ClientResponse;
 import org.springframework.cloud.appbroker.oauth2.DeleteOAuth2ClientRequest;
 import org.springframework.cloud.appbroker.oauth2.DeleteOAuth2ClientResponse;
 import org.springframework.cloud.appbroker.oauth2.OAuth2Client;
-import reactor.core.publisher.Mono;
-import reactor.test.StepVerifier;
-
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -69,9 +71,9 @@ class SpringSecurityOAuth2CredentialProviderFactoryTest {
 		BackingApplication backingApplication = BackingApplication.builder()
 			.build();
 
-		when(credentialGenerator.generateString(backingApplication.getName(), "service-instance-id",
+		when(credentialGenerator.generateString(backingApplication.getName(), "service-instance-id", "oauth2",
 			8, true, false, true, false))
-			.thenReturn("test-secret");
+			.thenReturn(Mono.just("test-secret"));
 
 		when(oAuth2Client.createClient(buildCreateOAuth2Request("test-id")))
 			.thenReturn(Mono.just(CreateOAuth2ClientResponse.builder().build()));
@@ -93,9 +95,9 @@ class SpringSecurityOAuth2CredentialProviderFactoryTest {
 			.build();
 		String clientId = backingApplication.getName() + "-" + "service-instance-id";
 
-		when(credentialGenerator.generateString(backingApplication.getName(), "service-instance-id",
+		when(credentialGenerator.generateString(backingApplication.getName(), "service-instance-id", "oauth2",
 			8, true, false, true, false))
-			.thenReturn("test-secret");
+			.thenReturn(Mono.just("test-secret"));
 
 		when(oAuth2Client.createClient(buildCreateOAuth2Request(clientId)))
 			.thenReturn(Mono.just(CreateOAuth2ClientResponse.builder().build()));
@@ -130,12 +132,15 @@ class SpringSecurityOAuth2CredentialProviderFactoryTest {
 		when(oAuth2Client.deleteClient(buildDeleteOAuth2Request("test-id")))
 			.thenReturn(Mono.just(DeleteOAuth2ClientResponse.builder().build()));
 
+		given(credentialGenerator.deleteString(backingApplication.getName(), "service-instance-id", "oauth2"))
+			.willReturn(Mono.empty());
+
 		StepVerifier
 			.create(provider.deleteCredentials(backingApplication, "service-instance-id"))
 			.expectNext(backingApplication)
 			.verifyComplete();
 
-		verify(credentialGenerator).deleteString(backingApplication.getName(), "service-instance-id");
+		verify(credentialGenerator).deleteString(backingApplication.getName(), "service-instance-id", "oauth2");
 		verifyNoMoreInteractions(credentialGenerator);
 	}
 
@@ -151,12 +156,15 @@ class SpringSecurityOAuth2CredentialProviderFactoryTest {
 		when(oAuth2Client.deleteClient(buildDeleteOAuth2Request(clientId)))
 			.thenReturn(Mono.just(DeleteOAuth2ClientResponse.builder().build()));
 
+		given(credentialGenerator.deleteString(backingApplication.getName(), "service-instance-id", "oauth2"))
+			.willReturn(Mono.empty());
+
 		StepVerifier
 			.create(provider.deleteCredentials(backingApplication, "service-instance-id"))
 			.expectNext(backingApplication)
 			.verifyComplete();
 
-		verify(credentialGenerator).deleteString(backingApplication.getName(), "service-instance-id");
+		verify(credentialGenerator).deleteString(backingApplication.getName(), "service-instance-id", "oauth2");
 		verifyNoMoreInteractions(credentialGenerator);
 	}
 

--- a/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGenerator.java
+++ b/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2016-2018 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+import reactor.util.function.Tuples;
+
+import org.springframework.credhub.core.ReactiveCredHubOperations;
+import org.springframework.credhub.support.CredentialDetails;
+import org.springframework.credhub.support.SimpleCredentialName;
+import org.springframework.credhub.support.password.PasswordCredential;
+import org.springframework.credhub.support.password.PasswordParameters;
+import org.springframework.credhub.support.password.PasswordParametersRequest;
+import org.springframework.credhub.support.user.UserCredential;
+import org.springframework.credhub.support.user.UserParametersRequest;
+
+public class CredHubCredentialsGenerator implements CredentialGenerator {
+
+	private final ReactiveCredHubOperations credHubOperations;
+
+	public CredHubCredentialsGenerator(ReactiveCredHubOperations credHubOperations) {
+		this.credHubOperations = credHubOperations;
+	}
+
+	@Override
+	public Mono<Tuple2<String, String>> generateUser(String applicationId, String serviceInstanceId, String descriptor,
+													 int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha,
+													 boolean includeNumeric, boolean includeSpecial) {
+		return this.credHubOperations.credentials().generate(UserParametersRequest
+			.builder()
+			.name(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor))
+			.parameters(passwordParameters(length, includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric, includeSpecial))
+			.build(), UserCredential.class)
+									 .map(CredentialDetails::getValue)
+									 .map(userCredential -> Tuples.of(userCredential.getUsername(), userCredential.getPassword()));
+	}
+
+	@Override
+	public Mono<String> generateString(String applicationId, String serviceInstanceId, String descriptor, int length,
+									   boolean includeUppercaseAlpha, boolean includeLowercaseAlpha, boolean includeNumeric,
+									   boolean includeSpecial) {
+		return credHubOperations.credentials().generate(PasswordParametersRequest
+			.builder()
+			.name(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor))
+			.parameters(passwordParameters(length, includeUppercaseAlpha, includeLowercaseAlpha, includeNumeric, includeSpecial))
+			.build(), PasswordCredential.class)
+								.map(CredentialDetails::getValue)
+								.map(PasswordCredential::getPassword);
+	}
+
+	@Override
+	public Mono<Void> deleteUser(String applicationId, String serviceInstanceId, String descriptor) {
+		return credHubOperations.credentials().deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
+	}
+
+	@Override
+	public Mono<Void> deleteString(String applicationId, String serviceInstanceId, String descriptor) {
+		return credHubOperations.credentials().deleteByName(new SimpleCredentialName(applicationId, serviceInstanceId, descriptor));
+	}
+
+	private PasswordParameters passwordParameters(int length, boolean includeUppercaseAlpha, boolean includeLowercaseAlpha,
+												  boolean includeNumeric, boolean includeSpecial) {
+		return PasswordParameters
+			.builder()
+			.length(length)
+			.excludeUpper(!includeUppercaseAlpha)
+			.excludeLower(!includeLowercaseAlpha)
+			.excludeNumber(!includeNumeric)
+			.includeSpecial(includeSpecial)
+			.build();
+	}
+}

--- a/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingCreateServiceInstanceAppBindingWorkflow.java
+++ b/spring-cloud-app-broker-security-credhub/src/main/java/org/springframework/cloud/appbroker/workflow/binding/CredHubPersistingCreateServiceInstanceAppBindingWorkflow.java
@@ -27,6 +27,7 @@ import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstan
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest;
 import org.springframework.core.annotation.Order;
 import org.springframework.credhub.core.ReactiveCredHubOperations;
+import org.springframework.credhub.support.ServiceInstanceCredentialName;
 import org.springframework.credhub.support.json.JsonCredentialRequest;
 import org.springframework.util.CollectionUtils;
 
@@ -37,7 +38,7 @@ public class CredHubPersistingCreateServiceInstanceAppBindingWorkflow implements
 
 	private static final String CREDENTIALS_KEY = "credhub-ref";
 
-	private static final String CREDENTIALS_VALUE_TEMPLATE = "/c/%s/%s/%s/credentials-json";
+	private static final String CREDENTIALS_NAME = "credentials-json";
 
 	private final String appName;
 
@@ -80,14 +81,17 @@ public class CredHubPersistingCreateServiceInstanceAppBindingWorkflow implements
 				.builder()
 				.async(response.isAsync())
 				.bindingExisted(response.isBindingExisted())
-				.credentials(CREDENTIALS_KEY, formatCredentials(request))
+				.credentials(CREDENTIALS_KEY, ServiceInstanceCredentialName
+					.builder()
+					.serviceBrokerName(this.appName)
+					.serviceOfferingName(request.getServiceDefinitionId())
+					.serviceBindingId(request.getBindingId())
+					.credentialName(CREDENTIALS_NAME)
+					.build()
+					.getName())
 				.operation(response.getOperation())
 				.syslogDrainUrl(response.getSyslogDrainUrl())
 				.volumeMounts(response.getVolumeMounts()));
-	}
-
-	private String formatCredentials(CreateServiceInstanceBindingRequest request) {
-		return String.format(CREDENTIALS_VALUE_TEMPLATE, this.appName, request.getServiceDefinitionId(), request.getBindingId());
 	}
 
 }

--- a/spring-cloud-app-broker-security-credhub/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGeneratorTest.java
+++ b/spring-cloud-app-broker-security-credhub/src/test/java/org/springframework/cloud/appbroker/extensions/credentials/CredHubCredentialsGeneratorTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2016-2018 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.appbroker.extensions.credentials;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.credhub.core.ReactiveCredHubOperations;
+import org.springframework.credhub.core.credential.ReactiveCredHubCredentialOperations;
+import org.springframework.credhub.support.CredentialDetails;
+import org.springframework.credhub.support.CredentialType;
+import org.springframework.credhub.support.SimpleCredentialName;
+import org.springframework.credhub.support.password.PasswordCredential;
+import org.springframework.credhub.support.password.PasswordParameters;
+import org.springframework.credhub.support.user.UserCredential;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class CredHubCredentialsGeneratorTest {
+
+	@Mock
+	private ReactiveCredHubOperations credHubOperations;
+
+	@Mock
+	private ReactiveCredHubCredentialOperations credHubCredentialOperations;
+
+	private CredHubCredentialsGenerator generator;
+
+	@BeforeEach
+	void setUp() {
+		this.generator = new CredHubCredentialsGenerator(credHubOperations);
+	}
+	
+	@Test
+	void passwordParameters() {
+		PasswordParameters params = ReflectionTestUtils.invokeMethod(generator, "passwordParameters", 42, false, false, false, false);
+		assertThat(params.getLength()).isEqualTo(42);
+		assertThat(params.getExcludeUpper()).isTrue();
+		assertThat(params.getExcludeLower()).isTrue();
+		assertThat(params.getExcludeNumber()).isTrue();
+		assertThat(params.getIncludeSpecial()).isFalse();
+	}
+
+	@Test
+	void generateUser() {
+		CredentialDetails<UserCredential> credentialDetails = new CredentialDetails<UserCredential>("id",
+			new SimpleCredentialName("app-service"), CredentialType.PASSWORD,
+			new UserCredential("username", "password"));
+
+		given(this.credHubOperations.credentials())
+			.willReturn(credHubCredentialOperations);
+
+		given(this.credHubCredentialOperations.generate(any(), eq(UserCredential.class)))
+			.willReturn(Mono.just(credentialDetails));
+
+		StepVerifier.create(generator.generateUser("foo", "bar", "hello", 12, false, false, false, false))
+					.assertNext(tuple2 -> {
+						assertThat(tuple2.getT1()).isEqualTo("username");
+						assertThat(tuple2.getT2()).isEqualTo("password");
+					})
+					.verifyComplete();
+	}
+
+	@Test
+	void generateString() {
+		CredentialDetails<PasswordCredential> credentialDetails = new CredentialDetails<PasswordCredential>("id",
+			new SimpleCredentialName("app-service"), CredentialType.PASSWORD,
+			new PasswordCredential("password"));
+
+		given(this.credHubOperations.credentials())
+			.willReturn(credHubCredentialOperations);
+
+		given(this.credHubCredentialOperations.generate(any(), eq(PasswordCredential.class)))
+			.willReturn(Mono.just(credentialDetails));
+
+		StepVerifier.create(generator.generateString("foo", "bar", "hello", 12, false, false, false, false))
+					.assertNext(password -> assertThat(password).isEqualTo("password"))
+					.verifyComplete();
+	}
+
+	@Test
+	void deleteUser() {
+		given(this.credHubOperations.credentials())
+			.willReturn(credHubCredentialOperations);
+
+		given(this.credHubCredentialOperations.deleteByName(new SimpleCredentialName("foo", "bar", "hello")))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(generator.deleteUser("foo", "bar", "hello"))
+					.verifyComplete();
+
+		verify(credHubCredentialOperations).deleteByName(new SimpleCredentialName("foo", "bar", "hello"));
+		verifyNoMoreInteractions(credHubOperations);
+		verifyNoMoreInteractions(credHubCredentialOperations);
+	}
+
+	@Test
+	void deleteString() {
+		given(this.credHubOperations.credentials())
+			.willReturn(credHubCredentialOperations);
+
+		given(this.credHubCredentialOperations.deleteByName(new SimpleCredentialName("foo", "bar", "hello")))
+			.willReturn(Mono.empty());
+
+		StepVerifier.create(generator.deleteString("foo", "bar", "hello"))
+					.verifyComplete();
+
+		verify(credHubCredentialOperations).deleteByName(new SimpleCredentialName("foo", "bar", "hello"));
+		verifyNoMoreInteractions(credHubOperations);
+		verifyNoMoreInteractions(credHubCredentialOperations);
+	}
+
+}


### PR DESCRIPTION
- Add `CredHubCredentialsGenerator`
- Update `CredHubAutoconfiguration` to conditionally create beans
- Refactor the `CredentialGenerator` interface to be reactive
- Replace use of Pair in favor of Tuple2

Resolves #152