### PR TITLE
Removing PMD rule

### DIFF
--- a/src/pmd/pmdTestRuleSet.xml
+++ b/src/pmd/pmdTestRuleSet.xml
@@ -66,10 +66,10 @@
 	</rule>
 	<rule ref="category/java/errorprone.xml">
 		<exclude name="AvoidDuplicateLiterals" />
-		<exclude name="BeanMembersShouldSerialize" />
 		<exclude name="DataflowAnomalyAnalysis" />
 		<exclude name="InvalidLogMessageFormat" />
 		<exclude name="NonStaticInitializer" />
+		<exclude name="TestClassWithoutTestCases" />
 	</rule>
 	<rule ref="category/java/multithreading.xml">
 		<exclude name="UseConcurrentHashMap" />


### PR DESCRIPTION
`TestClassWithoutTestCases` matches any test class that has `Test` on the name and expects to have a test on it. We have a naming convention where we use the name `Test` for some test resources that don't need tests.

`BeanMembersShouldSerialize` was removed.