### PR TITLE
(2.4.x) Bump to reactor-netty 1.2.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,15 @@ configure(javaProjects) {
 	task allDependencyInsight(type: DependencyInsightReportTask)
 	task dependencyReport(type: DependencyReportTask)
 
+	configurations.configureEach {
+		resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+			if (details.requested.group == 'io.projectreactor.netty' && details.requested.version == '1.2.3') {
+				details.useVersion '1.2.4'
+				details.because 'fix https://github.com/reactor/reactor-netty/issues/3660'
+			}
+		}
+	}
+
 	java {
 		toolchain {
 			languageVersion = JavaLanguageVersion.of(17)


### PR DESCRIPTION
Contains fix for reactor/reactor-netty#3660, which was breaking ATs.