### PR TITLE
Add Javadoc to ParametersTransformer

### DIFF
--- a/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformer.java
+++ b/spring-cloud-app-broker-core/src/main/java/org/springframework/cloud/appbroker/extensions/parameters/ParametersTransformer.java
@@ -20,6 +20,10 @@ import java.util.Map;
 
 import reactor.core.publisher.Mono;
 
+/**
+ * Mutates the provided backing type.
+ * Returned value is effectively ignored.
+ */
 @FunctionalInterface
 public interface ParametersTransformer<T> {
 


### PR DESCRIPTION
Given recent research, I'd like to document in the class what the expectation is for the returned value.

We could consider changing the logic so that the value is used; this will reduce reliance on mutation. However, the rest of the core relies on passing the same instance to other methods. So I don't feel confident that this is an easy change.