### PR TITLE
Per-request Organization Configuration

### DIFF
--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployer.java
@@ -408,7 +408,13 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		else {
 			space = this.targetProperties.getDefaultSpace();
 		}
-		return this.operations.spaces().get(GetSpaceRequest.builder().name(space).build()).map(SpaceDetail::getId);
+
+		return this.operationsUtils
+			.getOperations(properties)
+			.flatMap(cfOperations -> cfOperations.spaces()
+				.get(GetSpaceRequest.builder().name(space).build())
+			)
+			.map(SpaceDetail::getId);
 	}
 
 	private String getDomainId(String domain, List<Domain> domains) {
@@ -669,16 +675,11 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 			.noStart(!start(deploymentProperties))
 			.build();
 
-		Mono<Void> requestPushApplication;
-		if (deploymentProperties.containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
-			String space = deploymentProperties.get(DeploymentProperties.TARGET_PROPERTY_KEY);
-			requestPushApplication = pushManifestInSpace(applicationManifestRequest, space);
-		}
-		else {
-			requestPushApplication = pushManifest(applicationManifestRequest);
-		}
-
-		return requestPushApplication
+		return this.operationsUtils
+			.getOperations(deploymentProperties)
+			.flatMap(cfOperations -> cfOperations.applications()
+				.pushManifest(applicationManifestRequest)
+			)
 			.doOnSuccess((v) -> LOG.info("Success pushing app manifest. appName={}", request.getName()))
 			.doOnError((e) -> LOG.error(String.format("Error pushing app manifest. appName=%s, " + ERROR_LOG_TEMPLATE,
 					request.getName(), e.getMessage()), e));
@@ -729,15 +730,6 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		}
 
 		return manifest.build();
-	}
-
-	private Mono<Void> pushManifest(PushApplicationManifestRequest request) {
-		return this.operations.applications().pushManifest(request);
-	}
-
-	private Mono<Void> pushManifestInSpace(PushApplicationManifestRequest request, String spaceName) {
-		return createSpace(spaceName).then(this.operationsUtils.getOperationsForSpace(spaceName))
-			.flatMap((cfOperations) -> cfOperations.applications().pushManifest(request));
 	}
 
 	private Mono<String> createSpace(String spaceName) {
@@ -803,42 +795,18 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		String appName = request.getName();
 		Map<String, String> deploymentProperties = request.getProperties();
 
-		Mono<Void> requestDeleteApplication;
-		if (deploymentProperties.containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
-			String space = deploymentProperties.get(DeploymentProperties.TARGET_PROPERTY_KEY);
-			requestDeleteApplication = deleteApplicationInSpace(appName, space);
-		}
-		else {
-			requestDeleteApplication = deleteApplication(appName);
-		}
-
-		return requestDeleteApplication.timeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiTimeout()))
+		return this.operationsUtils
+			.getOperations(deploymentProperties)
+			.flatMap(cfOperations -> cfOperations.applications()
+				.delete(DeleteApplicationRequest.builder()
+					.deleteRoutes(this.defaultDeploymentProperties.isDeleteRoutes())
+					.name(appName)
+					.build())
+			)
+			.timeout(Duration.ofSeconds(this.defaultDeploymentProperties.getApiTimeout()))
 			.doOnSuccess((v) -> LOG.info("Success undeploying application. appName={}", appName))
 			.doOnError(logError(String.format("Error undeploying application. appName=%s", appName)))
 			.then(Mono.just(UndeployApplicationResponse.builder().name(appName).build()));
-	}
-
-	private Mono<Void> deleteApplication(String name) {
-		return this.operations.applications()
-			.delete(DeleteApplicationRequest.builder()
-				.deleteRoutes(this.defaultDeploymentProperties.isDeleteRoutes())
-				.name(name)
-				.build());
-	}
-
-	private Mono<Void> deleteApplicationInSpace(String name, String spaceName) {
-		return getSpaceId(spaceName)
-			.doOnError((e) -> LOG.error(String.format("Unable to get space name. spaceName=%s, " + ERROR_LOG_TEMPLATE,
-					spaceName, e.getMessage()), e))
-			.then(this.operationsUtils.getOperationsForSpace(spaceName))
-			.flatMap((cfOperations) -> cfOperations.applications()
-				.delete(DeleteApplicationRequest.builder()
-					.deleteRoutes(this.defaultDeploymentProperties.isDeleteRoutes())
-					.name(name)
-					.build())
-				.doOnError((e) -> LOG.error(String
-					.format("Error deleting application. appName=%s, " + ERROR_LOG_TEMPLATE, name, e.getMessage()), e)))
-			.onErrorResume((e) -> Mono.empty());
 	}
 
 	@Override
@@ -1120,11 +1088,13 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 	}
 
 	private Mono<ServiceInstance> getServiceInstance(String name, SpaceEntity spaceEntity) {
-		return getOrganization(spaceEntity.getOrganizationId()).flatMap((organizationEntity) -> this.operationsUtils
-			.getOperationsForOrgAndSpace(organizationEntity.getName(), spaceEntity.getName())
+		return getOrganization(spaceEntity.getOrganizationId())
+			.flatMap((organizationEntity) -> this.operationsUtils
+				.getOperationsForOrgAndSpace(organizationEntity.getName(), spaceEntity.getName())
+			)
 			.flatMap((cfOperations) -> cfOperations.services()
-				.getInstance(
-						org.cloudfoundry.operations.services.GetServiceInstanceRequest.builder().name(name).build())));
+				.getInstance(org.cloudfoundry.operations.services.GetServiceInstanceRequest.builder().name(name).build())
+			);
 	}
 
 	private Mono<ServiceInstanceEntity> getServiceInstance(String serviceInstanceId) {
@@ -1161,18 +1131,12 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		Mono<CreateServiceInstanceResponse> createServiceInstanceResponseMono = Mono
 			.just(CreateServiceInstanceResponse.builder().name(request.getServiceInstanceName()).build());
 
-		if (request.getProperties().containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
-			return createSpace(request.getProperties().get(DeploymentProperties.TARGET_PROPERTY_KEY))
-				.then(this.operationsUtils.getOperations(request.getProperties())
-					.flatMap((cfOperations) -> cfOperations.services()
-						.createInstance(createServiceInstanceRequest)
-						.then(createServiceInstanceResponseMono)));
-		}
-		else {
-			return this.operations.services()
+		return this.operationsUtils
+			.getOperations(request.getProperties())
+			.flatMap(cfOperations -> cfOperations.services()
 				.createInstance(createServiceInstanceRequest)
-				.then(createServiceInstanceResponseMono);
-		}
+			)
+			.then(createServiceInstanceResponseMono);
 	}
 
 	@Override
@@ -1187,18 +1151,12 @@ public class CloudFoundryAppDeployer implements AppDeployer, ResourceLoaderAware
 		String serviceInstanceName = request.getServiceInstanceName();
 		Map<String, String> deploymentProperties = request.getProperties();
 
-		Mono<Void> requestDeleteServiceInstance;
-		if (deploymentProperties.containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
-			requestDeleteServiceInstance = this.operationsUtils.getOperations(deploymentProperties)
-				.flatMap((cfOperations) -> unbindServiceInstance(serviceInstanceName, cfOperations)
-					.then(deleteServiceInstance(serviceInstanceName, cfOperations, deploymentProperties)));
-		}
-		else {
-			requestDeleteServiceInstance = unbindServiceInstance(serviceInstanceName, this.operations)
-				.then(deleteServiceInstance(serviceInstanceName, this.operations, deploymentProperties));
-		}
-
-		return requestDeleteServiceInstance
+		return this.operationsUtils
+			.getOperations(request.getProperties())
+			.flatMap(cfOperations ->
+				unbindServiceInstance(serviceInstanceName, cfOperations)
+					.then(deleteServiceInstance(serviceInstanceName, cfOperations, deploymentProperties))
+			)
 			.doOnSuccess(
 					(v) -> LOG.info("Success deleting service instance. serviceInstanceName={}", serviceInstanceName))
 			.doOnError(logError(

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtils.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/main/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtils.java
@@ -34,29 +34,28 @@ public class CloudFoundryOperationsUtils {
 	}
 
 	protected Mono<CloudFoundryOperations> getOperations(Map<String, String> properties) {
-		return Mono.defer(() -> {
-			if (!CollectionUtils.isEmpty(properties)
-					&& properties.containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
-				return getOperationsForSpace(properties.get(DeploymentProperties.TARGET_PROPERTY_KEY));
+		return Mono.fromSupplier(() -> {
+			DefaultCloudFoundryOperations.Builder builder = DefaultCloudFoundryOperations.builder()
+				.from((DefaultCloudFoundryOperations) this.operations);
+
+			if (!CollectionUtils.isEmpty(properties) && properties.containsKey(DeploymentProperties.ORGANIZATION_PROPERTY_KEY)) {
+				builder.organization(properties.get(DeploymentProperties.ORGANIZATION_PROPERTY_KEY));
 			}
-			return Mono.just(this.operations);
+
+			if (!CollectionUtils.isEmpty(properties) && properties.containsKey(DeploymentProperties.TARGET_PROPERTY_KEY)) {
+				builder.space(properties.get(DeploymentProperties.TARGET_PROPERTY_KEY));
+			}
+
+			return builder.build();
 		});
 	}
 
-	protected Mono<CloudFoundryOperations> getOperationsForSpace(String space) {
-		return Mono.just(this.operations)
-			.cast(DefaultCloudFoundryOperations.class)
-			.map((cfOperations) -> DefaultCloudFoundryOperations.builder().from(cfOperations).space(space).build());
-	}
-
 	protected Mono<CloudFoundryOperations> getOperationsForOrgAndSpace(String organization, String space) {
-		return Mono.just(this.operations)
-			.cast(DefaultCloudFoundryOperations.class)
-			.map((cfOperations) -> DefaultCloudFoundryOperations.builder()
-				.from(cfOperations)
-				.organization(organization)
-				.space(space)
-				.build());
+		return Mono.fromSupplier(() -> DefaultCloudFoundryOperations.builder()
+			.from((DefaultCloudFoundryOperations) this.operations)
+			.organization(organization)
+			.space(space)
+			.build());
 	}
 
 }

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTests.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerTests.java
@@ -163,7 +163,7 @@ class CloudFoundryAppDeployerTests {
 		given(this.cloudFoundryClient.organizations()).willReturn(this.clientOrganizations);
 		given(this.cloudFoundryClient.applicationsV2()).willReturn(this.clientApplications);
 		given(this.operationsUtils.getOperations(anyMap())).willReturn(Mono.just(this.cloudFoundryOperations));
-		given(this.operationsUtils.getOperationsForSpace(anyString()))
+		given(this.operationsUtils.getOperationsForOrgAndSpace(anyString(), anyString()))
 			.willReturn(Mono.just(this.cloudFoundryOperations));
 		given(this.operationsUtils.getOperationsForOrgAndSpace(anyString(), anyString()))
 			.willReturn(Mono.just(this.cloudFoundryOperations));

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTests.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryAppDeployerUpdateApplicationTests.java
@@ -173,7 +173,7 @@ class CloudFoundryAppDeployerUpdateApplicationTests {
 		given(this.cloudFoundryClient.deploymentsV3()).willReturn(this.deploymentsV3);
 		given(this.cloudFoundryClient.routes()).willReturn(this.routes);
 		given(this.operationsUtils.getOperations(anyMap())).willReturn(Mono.just(this.cloudFoundryOperations));
-		given(this.operationsUtils.getOperationsForSpace(anyString()))
+		given(this.operationsUtils.getOperationsForOrgAndSpace(anyString(), anyString()))
 			.willReturn(Mono.just(this.cloudFoundryOperations));
 
 		this.appDeployer = new CloudFoundryAppDeployer(deploymentProperties, this.cloudFoundryOperations,

--- a/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtilsTests.java
+++ b/spring-cloud-app-broker-deployer-cloudfoundry/src/test/java/org/springframework/cloud/appbroker/deployer/cloudfoundry/CloudFoundryOperationsUtilsTests.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.appbroker.deployer.cloudfoundry;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.cloudfoundry.operations.CloudFoundryOperations;
 import org.cloudfoundry.operations.DefaultCloudFoundryOperations;
@@ -43,29 +45,34 @@ class CloudFoundryOperationsUtilsTests {
 
 	@Test
 	void getOperationsWithEmptyProperties() {
-		StepVerifier.create(this.operationsUtils.getOperations(Collections.emptyMap()))
-			.expectNext(this.operations)
-			.verifyComplete();
-	}
-
-	@Test
-	void getOperationsWithProperties() {
 		StepVerifier
-			.create(this.operationsUtils
-				.getOperations(Collections.singletonMap(DeploymentProperties.TARGET_PROPERTY_KEY, "foo-space1")))
+			.create(this.operationsUtils.getOperations(Collections.emptyMap()))
 			.assertNext((ops) -> {
+				String organization = (String) ReflectionTestUtils.getField(ops, "organization");
+				assertThat(organization).isNull();
+
 				String space = (String) ReflectionTestUtils.getField(ops, "space");
-				assertThat(space).isEqualTo("foo-space1");
+				assertThat(space).isNull();
 			})
 			.verifyComplete();
 	}
 
 	@Test
-	void getOperationsForSpace() {
-		StepVerifier.create(this.operationsUtils.getOperationsForSpace("foo-space2")).assertNext((ops) -> {
-			String space = (String) ReflectionTestUtils.getField(ops, "space");
-			assertThat(space).isEqualTo("foo-space2");
-		}).verifyComplete();
+	void getOperationsWithProperties() {
+		Map<String, String> properties = new HashMap<>();
+		properties.put(DeploymentProperties.ORGANIZATION_PROPERTY_KEY, "foo-organization-1");
+		properties.put(DeploymentProperties.TARGET_PROPERTY_KEY, "foo-space-1");
+
+		StepVerifier
+			.create(this.operationsUtils.getOperations(properties))
+			.assertNext((ops) -> {
+				String organization = (String) ReflectionTestUtils.getField(ops, "organization");
+				assertThat(organization).isEqualTo("foo-organization-1");
+
+				String space = (String) ReflectionTestUtils.getField(ops, "space");
+				assertThat(space).isEqualTo("foo-space-1");
+			})
+			.verifyComplete();
 	}
 
 }

--- a/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/deployer/DeploymentProperties.java
+++ b/spring-cloud-app-broker-deployer/src/main/java/org/springframework/cloud/appbroker/deployer/deployer/DeploymentProperties.java
@@ -66,6 +66,11 @@ public class DeploymentProperties {
 	public static final String TARGET_PROPERTY_KEY = "target";
 
 	/**
+	 * The deployment property for the organization where the app will be deployed.
+	 */
+	public static final String ORGANIZATION_PROPERTY_KEY = "organization";
+
+	/**
 	 * The deployment property indicating whether the application should be automatically
 	 * started after deployment. Defaults to true.
 	 */


### PR DESCRIPTION
Previously whenever a request was made to deploy a service, only the target (space) could be changed on a per-request basis.  This change adds support for configuring the organization on a per-request basis as well.

This change adds a new `DeploymentProperty` called '`organization`' as a peer to '`target`'.  `CloudFoundryOperationsUtils` is updated to only have two ways to configure the `CloudFoundryOperations`, both of which encapsulate the setting both the org and space.  The ability to change only the space is removed.  The rest of the change is updating and simplifying the rest of the code to remove the branches were the space was optionally set in favor of always using the `OperationsUtils`, passing in the properties where the optionality is centralized.
